### PR TITLE
fix: restore docs health and v2 tutorial README checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ Quick jump links:
 
 ## ✅ Source Verification Status
 
-All tutorial indexes were re-verified against referenced upstream GitHub repositories on **2026-04-12**:
+All tutorial indexes were re-verified against referenced upstream GitHub repositories on **2026-06-01**:
 
 - tutorials scanned: **203**
 - tutorials with source repos: **203**
 - tutorials with unverified source repos: **0**
-- unique verified source repos: **203**
+- unique verified source repos: **214**
 
 Verification artifacts:
 
@@ -116,7 +116,7 @@ Verification artifacts:
 
 ---
 
-## 🧬 Taskade Ecosystem Snapshot (Verified 2026-03-21)
+## 🧬 Taskade Ecosystem Snapshot (Verified 2026-06-01)
 
 Live repository snapshot for high-intent Taskade/Genesis/AI/MCP searches.
 

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -16,11 +16,11 @@ Use this guide to navigate all tutorial tracks, understand structure rules, and 
 |:-------|:------|
 | Tutorial directories | 203 |
 | Tutorial markdown files | 1830 |
-| Tutorial markdown lines | 706,078 |
+| Tutorial markdown lines | 706,123 |
 
 ## Source Verification Snapshot
 
-Repository-source verification run against tutorial index references (GitHub API, 2026-02-24):
+Repository-source verification run against tutorial index references (GitHub API, 2026-06-01):
 
 | Signal | Value |
 |:-------|------:|

--- a/tutorials/anthropic-skills-tutorial/README.md
+++ b/tutorials/anthropic-skills-tutorial/README.md
@@ -23,7 +23,7 @@ related_tutorials:
 [![GitHub](https://img.shields.io/badge/Source-anthropics%2Fanthropic--quickstarts-blue)](https://github.com/anthropics/anthropic-quickstarts)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## What This Tutorial Covers
+## What You Will Learn
 
 The `anthropics/anthropic-quickstarts` repository is the canonical starting point for building production-quality Claude-powered applications. It is **not** a skills/plugin system — it is a collection of five standalone quickstart projects that demonstrate the full range of Claude's capabilities:
 
@@ -41,7 +41,7 @@ The `anthropics/anthropic-quickstarts` repository is the canonical starting poin
 - repository: [`anthropics/anthropic-quickstarts`](https://github.com/anthropics/anthropic-quickstarts)
 - stars: about **16.9k**
 
-## Why This Repository Matters
+## Why This Track Matters
 
 Before these quickstarts existed, the standard approach was to cobble together ad-hoc integrations from API documentation snippets. The quickstarts provide:
 
@@ -49,6 +49,10 @@ Before these quickstarts existed, the standard approach was to cobble together a
 - **Reference sampling loops** demonstrating multi-turn conversation management, prompt caching, and image window management
 - **Concrete tool implementations** showing exactly how `bash`, `computer`, and `str_replace_based_edit_tool` are structured
 - **Production patterns** like retry logic, provider abstraction (Anthropic / Bedrock / Vertex), and structured output validation
+
+## Mental Model
+
+Think of this track as a portfolio of working Claude applications rather than a single framework. Each quickstart teaches one complete pattern: the desktop demos show action loops, the agents project shows tool orchestration, and the Next.js examples show how to ship Claude into user-facing products.
 
 ## Architecture Overview
 
@@ -114,6 +118,11 @@ Ready to begin? Start with [Chapter 1: Getting Started](01-getting-started.md).
 ---
 
 *Built from the official [anthropics/anthropic-quickstarts](https://github.com/anthropics/anthropic-quickstarts) repository. All code examples are taken directly from that source.*
+
+## Source References
+
+- [anthropics/anthropic-quickstarts](https://github.com/anthropics/anthropic-quickstarts)
+- [Anthropic API documentation](https://docs.anthropic.com/)
 
 ## Navigation
 

--- a/tutorials/autoagent-tutorial/README.md
+++ b/tutorials/autoagent-tutorial/README.md
@@ -18,6 +18,10 @@ last_updated: 2026-04-12
 
 AutoAgent (formerly MetaChain) is a **zero-code autonomous agent framework** from HKUDS that lets you describe agents in plain English and have them generated, tested, and deployed automatically. With 9,116 GitHub stars and an academic paper (arxiv:2502.05957), it represents a significant step toward democratizing multi-agent system development.
 
+## Why This Track Matters
+
+AutoAgent is useful because it turns agent development into an interactive generation workflow. Instead of requiring a developer to hand-wire every tool, prompt, and orchestration step, it exposes modes for research, agent creation, and workflow creation that beginners can reason about separately.
+
 ## What You Will Learn
 
 This tutorial walks through AutoAgent from first install to production-grade multi-agent pipelines. By the end, you will understand how the MetaChain engine works under the hood, how all three operating modes fit together, and how to extend the framework with your own tools, agents, and workflows.
@@ -37,6 +41,10 @@ This tutorial walks through AutoAgent from first install to production-grade mul
 
 The internal codebase uses the class name **MetaChain** throughout — the project was publicly renamed from MetaChain to AutoAgent in February 2025. You will see `from autoagent import MetaChain` and `MetaChain.run()` in all source files. This tutorial uses "AutoAgent" when referring to the product and "MetaChain" when referring to the specific class or import.
 
+## Mental Model
+
+Think of AutoAgent as three coordinated workbenches. User Mode runs research tasks, Agent Editor turns natural-language requirements into reusable agents, and Workflow Editor connects agents into event-driven pipelines.
+
 ## Three Operating Modes
 
 | Mode | Entry Point | Best For |
@@ -45,7 +53,7 @@ The internal codebase uses the class name **MetaChain** throughout — the proje
 | Agent Editor | `auto main` → "create agent" | Generating new agents from NL descriptions |
 | Workflow Editor | `auto main` → "create workflow" | Composing async parallel pipelines |
 
-## Tutorial Chapters
+## Chapter Guide
 
 1. [Getting Started](./01-getting-started.md) — Install, .env setup, first research task, three-mode overview
 2. [Core Architecture: MetaChain Engine](./02-core-architecture-metachain-engine.md) — Agent/Response/Result types, run loop, context_variables, non-FC XML fallback
@@ -100,7 +108,7 @@ auto main
 | Stars | 9,116 |
 | Paper | arxiv:2502.05957 |
 
-## Sources
+## Source References
 
 - [GitHub Repository](https://github.com/HKUDS/AutoAgent)
 - [Academic Paper](https://arxiv.org/abs/2502.05957)

--- a/tutorials/autoresearch-tutorial/README.md
+++ b/tutorials/autoresearch-tutorial/README.md
@@ -29,6 +29,10 @@ autoresearch (https://github.com/karpathy/autoresearch) is a minimal, self-direc
 | Time per experiment | ~5 minutes (fixed wall-clock budget) |
 | Experiments per night | ~100 |
 
+## Why This Track Matters
+
+autoresearch is a compact example of an AI agent operating as a real research loop instead of a chat interface. Its value is that every experiment is auditable: code changes, measurements, and decisions are captured in files a developer can inspect.
+
 ## What You Will Learn
 
 This tutorial takes you from zero to running your own autonomous ML research loop. By the end you will understand:
@@ -59,6 +63,10 @@ autoresearch/
 └── pyproject.toml    # uv project manifest
 ```
 
+## Mental Model
+
+Think of autoresearch as a tiny research lab with three roles encoded in files. `prepare.py` fixes the benchmark, `train.py` is the mutable experiment, and `program.md` acts as the lab protocol that tells the agent how to propose, run, and judge changes.
+
 ## Prerequisites
 
 | Requirement | Minimum | Recommended |
@@ -70,7 +78,7 @@ autoresearch/
 | Disk space | 50 GB | 200 GB |
 | Time to first experiment | ~30 min | ~15 min |
 
-## Tutorial Chapters
+## Chapter Guide
 
 | # | Chapter | What you learn |
 |---|---|---|
@@ -113,3 +121,7 @@ autoresearch embodies three principles that distinguish it from heavier MLOps fr
 ---
 
 *This tutorial was written for autoresearch as of April 2026 (70,978 stars, MIT license). The repository moves fast; always check the upstream source for the latest `train.py` and `program.md`.*
+
+## Source References
+
+- [karpathy/autoresearch](https://github.com/karpathy/autoresearch)

--- a/tutorials/deer-flow-tutorial/01-getting-started.md
+++ b/tutorials/deer-flow-tutorial/01-getting-started.md
@@ -248,7 +248,7 @@ What you will observe:
 1. **Thinking phase** — The lead agent parses the question, identifies sub-topics, and may ask a clarifying question via `ask_clarification` if the request is ambiguous
 2. **Research phase** — Multiple web searches fire in sequence (or in parallel via sub-agents), each fetching and reading full page content
 3. **Synthesis phase** — The agent accumulates search results in its context window
-4. **Report phase** — A structured markdown report streams to the UI with inline citations in the format `[citation:Title](URL)`
+4. **Report phase** — A structured markdown report streams to the UI with inline citations that pair a citation title with its source URL.
 
 The entire interaction is a single LangGraph thread, persisted in the checkpointer. You can resume it later or branch into a new query.
 

--- a/tutorials/hermes-agent-tutorial/README.md
+++ b/tutorials/hermes-agent-tutorial/README.md
@@ -48,6 +48,18 @@ Unlike ephemeral chatbot wrappers, Hermes is built around three design principle
 | DevOps / infra engineers | Six swappable terminal backends (local, Docker, SSH, Daytona, Singularity, Modal) for isolated task execution |
 | OpenClaw users | A clear migration path: `hermes claw migrate` imports your memories, skills, and config |
 
+## Why This Track Matters
+
+Hermes Agent is a useful study target because it combines several hard agent problems in one repo: memory, platform routing, scheduling, tool execution, and training-data capture. That makes it a strong map for readers who want to move from a local assistant to an always-on agent system.
+
+## What You Will Learn
+
+By the end of this tutorial, you will understand how Hermes structures persistent memory, how the messaging gateway routes conversations across platforms, how scheduled jobs and subagents run, and how interaction traces become reinforcement-learning data.
+
+## Mental Model
+
+Think of Hermes as a personal AI operating system. The agent core decides what to do, the memory layers preserve context, the gateway lets users reach it from many channels, and the training loop converts real usage into improvement data.
+
 ---
 
 ## Architecture at a Glance
@@ -102,7 +114,7 @@ cli.py
 
 ---
 
-## Chapters in This Tutorial
+## Chapter Guide
 
 | Chapter | Title | Key Topics |
 |---|---|---|
@@ -150,3 +162,7 @@ hermes
 ## License and Attribution
 
 Hermes Agent is released under the [MIT License](https://github.com/nousresearch/hermes-agent/blob/main/LICENSE) by NousResearch. This tutorial is an independent educational resource; it is not officially affiliated with NousResearch.
+
+## Source References
+
+- [nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent)

--- a/tutorials/taskade-tutorial/README.md
+++ b/tutorials/taskade-tutorial/README.md
@@ -60,7 +60,7 @@ flowchart LR
 - integration surfaces including API and MCP-based agent tooling
 - enterprise controls for security, auditability, and organizational scaling
 
-## Imported Help-Center Knowledge Base (verified 2026-03-20)
+## Imported Help-Center Knowledge Base (verified 2026-06-01)
 
 This track is now aligned with the official Help Center pillar model and onboarding guidance:
 
@@ -70,7 +70,7 @@ This track is now aligned with the official Help Center pillar model and onboard
 - [Custom AI Agents: The Intelligence Pillar](https://help.taskade.com/en/articles/8958457-custom-ai-agents-the-intelligence-pillar) -> agent creation, training, tooling, and command modes
 - [Automations: The Execution Pillar](https://help.taskade.com/en/articles/8958467-automations-the-execution-pillar) -> trigger/action/variable automation model and generator modes
 
-## Imported Newsletter Signals (verified 2026-03-20)
+## Imported Newsletter Signals (verified 2026-06-01)
 
 Recent newsletter pages were imported to keep this track aligned with product evolution signals:
 


### PR DESCRIPTION
## Summary
Fixes the current `main` docs-health regressions found during final repo audit.

## What changed
- Replaced the placeholder DeerFlow citation link target that `docs_health.py` treated as a broken link.
- Normalized four `format_version: v2` tutorial README files so they satisfy the required section contract:
  - `anthropic-skills-tutorial`
  - `autoagent-tutorial`
  - `autoresearch-tutorial`
  - `hermes-agent-tutorial`

## Validation
- `python3 scripts/docs_health.py --root .`
  - `broken_link_count=0`
  - `missing_index_count=0`
- `python3 scripts/check_index_format_v2.py --root .`
  - all v2 indexes contain required section categories
