### PR TITLE
docs: convert release claims to checked GitHub references

### DIFF
--- a/scripts/refresh_tutorial_snapshots.py
+++ b/scripts/refresh_tutorial_snapshots.py
@@ -4,7 +4,7 @@
 For each tutorial:
 1. Read the README.md
 2. Look up source repo from tutorial-source-verification.json
-3. Fetch latest repo metadata and release from GitHub API
+3. Fetch repo metadata and the GitHub release snapshot from the GitHub API
 4. Update or insert the Current Snapshot section
 """
 
@@ -49,7 +49,7 @@ def _gh_request(url: str, token: str | None) -> dict[str, Any] | None:
 
 
 def fetch_repo_data(repo: str, token: str | None) -> dict[str, Any]:
-    """Fetch repo metadata + latest release for a GitHub repo."""
+    """Fetch repo metadata and release snapshot for a GitHub repo."""
     base = _gh_request(f"https://api.github.com/repos/{repo}", token)
     if not base:
         return {"repo": repo, "stars": None, "release_tag": None}
@@ -173,9 +173,9 @@ def build_snapshot_lines(data: dict[str, Any]) -> list[str]:
         lines.append(f"- stars: about {format_stars(data['stars'])}")
     if data.get("release_tag"):
         tag = data["release_tag"]
-        release_line = f"- latest release: [`{tag}`](https://github.com/{repo}/releases/tag/{tag})"
-        if data.get("release_date"):
-            release_line += f" (published {data['release_date']})"
+        checked_on = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        release_line = f"- GitHub release reference: [`{tag}`](https://github.com/{repo}/releases/tag/{tag})"
+        release_line += f" (checked {checked_on}; release metadata on GitHub)"
         lines.append(release_line)
     if data.get("archived"):
         lines.append("- status: **archived**")

--- a/templates/tutorial-index-template-v2.md
+++ b/templates/tutorial-index-template-v2.md
@@ -24,7 +24,7 @@ format_version: v2
 
 - repository: `<org>/<repo>`
 - stars: about **<N>**
-- latest release/version: `<tag or version>`
+- GitHub release reference/version: `<tag or version>` (checked `<YYYY-MM-DD>`)
 - current focus: <short note>
 
 ## <Tutorial Name> Mental Model

--- a/tutorials/a2a-protocol-tutorial/README.md
+++ b/tutorials/a2a-protocol-tutorial/README.md
@@ -32,7 +32,7 @@ This track focuses on:
 
 - repository: [`a2aproject/A2A`](https://github.com/a2aproject/A2A)
 - stars: about **24.1k**
-- latest release: [`v1.0.1`](https://github.com/a2aproject/A2A/releases/tag/v1.0.1) (published 2026-05-28)
+- GitHub release reference: [`v1.0.1`](https://github.com/a2aproject/A2A/releases/tag/v1.0.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/activepieces-tutorial/README.md
+++ b/tutorials/activepieces-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`activepieces/activepieces`](https://github.com/activepieces/activepieces)
 - stars: about **22.5k**
-- latest release: [`0.84.0`](https://github.com/activepieces/activepieces/releases/tag/0.84.0) (published 2026-05-29)
+- GitHub release reference: [`0.84.0`](https://github.com/activepieces/activepieces/releases/tag/0.84.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/adk-python-tutorial/README.md
+++ b/tutorials/adk-python-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`google/adk-python`](https://github.com/google/adk-python)
 - stars: about **19.9k**
-- latest release: [`v2.1.0`](https://github.com/google/adk-python/releases/tag/v2.1.0) (published 2026-05-23)
+- GitHub release reference: [`v2.1.0`](https://github.com/google/adk-python/releases/tag/v2.1.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/affine-tutorial/README.md
+++ b/tutorials/affine-tutorial/README.md
@@ -38,7 +38,7 @@ This track focuses on:
 
 - repository: [`toeverything/AFFiNE`](https://github.com/toeverything/AFFiNE)
 - stars: about **69k**
-- latest release: [`v0.26.3`](https://github.com/toeverything/AFFiNE/releases/tag/v0.26.3) (published 2026-02-25)
+- GitHub release reference: [`v0.26.3`](https://github.com/toeverything/AFFiNE/releases/tag/v0.26.3) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/ag2-tutorial/README.md
+++ b/tutorials/ag2-tutorial/README.md
@@ -86,7 +86,7 @@ flowchart TD
 
 - repository: [`ag2ai/ag2`](https://github.com/ag2ai/ag2)
 - stars: about **4.6k**
-- latest release: [`v0.13.2`](https://github.com/ag2ai/ag2/releases/tag/v0.13.2) (published 2026-05-29)
+- GitHub release reference: [`v0.13.2`](https://github.com/ag2ai/ag2/releases/tag/v0.13.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Core Concepts
 

--- a/tutorials/agentgpt-tutorial/README.md
+++ b/tutorials/agentgpt-tutorial/README.md
@@ -76,7 +76,7 @@ Welcome to your journey through autonomous AI agent development! This tutorial e
 
 - repository: [`reworkd/AgentGPT`](https://github.com/reworkd/AgentGPT)
 - stars: about **36.2k**
-- latest release: [`v.1.0.0`](https://github.com/reworkd/AgentGPT/releases/tag/v.1.0.0) (published 2023-11-02)
+- GitHub release reference: [`v.1.0.0`](https://github.com/reworkd/AgentGPT/releases/tag/v.1.0.0) (checked 2026-06-02; release metadata on GitHub)
 - status: **archived**
 
 ## What You Will Learn

--- a/tutorials/agno-tutorial/README.md
+++ b/tutorials/agno-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`agno-agi/agno`](https://github.com/agno-agi/agno)
 - stars: about **40.4k**
-- latest release: [`v2.6.9`](https://github.com/agno-agi/agno/releases/tag/v2.6.9) (published 2026-05-21)
+- GitHub release reference: [`v2.6.9`](https://github.com/agno-agi/agno/releases/tag/v2.6.9) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/aider-tutorial/README.md
+++ b/tutorials/aider-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`Aider-AI/aider`](https://github.com/Aider-AI/aider)
 - stars: about **45.6k**
-- latest release: [`v0.86.0`](https://github.com/Aider-AI/aider/releases/tag/v0.86.0) (published 2025-08-09)
+- GitHub release reference: [`v0.86.0`](https://github.com/Aider-AI/aider/releases/tag/v0.86.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/anything-llm-tutorial/README.md
+++ b/tutorials/anything-llm-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`Mintplex-Labs/anything-llm`](https://github.com/Mintplex-Labs/anything-llm)
 - stars: about **60.9k**
-- latest release: [`v1.13.0`](https://github.com/Mintplex-Labs/anything-llm/releases/tag/v1.13.0) (published 2026-05-26)
+- GitHub release reference: [`v1.13.0`](https://github.com/Mintplex-Labs/anything-llm/releases/tag/v1.13.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/appsmith-tutorial/README.md
+++ b/tutorials/appsmith-tutorial/README.md
@@ -35,7 +35,7 @@ This track focuses on:
 
 - repository: [`appsmithorg/appsmith`](https://github.com/appsmithorg/appsmith)
 - stars: about **39.9k**
-- latest release: [`v2.1`](https://github.com/appsmithorg/appsmith/releases/tag/v2.1) (published 2026-05-29)
+- GitHub release reference: [`v2.1`](https://github.com/appsmithorg/appsmith/releases/tag/v2.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/athens-research-tutorial/README.md
+++ b/tutorials/athens-research-tutorial/README.md
@@ -126,7 +126,7 @@ Ready to begin? Start with [Chapter 1: System Overview](01-system-overview.md).
 
 - repository: [`athensresearch/athens`](https://github.com/athensresearch/athens)
 - stars: about **6.3k**
-- latest release: [`v2.0.0`](https://github.com/athensresearch/athens/releases/tag/v2.0.0) (published 2022-08-22)
+- GitHub release reference: [`v2.0.0`](https://github.com/athensresearch/athens/releases/tag/v2.0.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/autogen-tutorial/README.md
+++ b/tutorials/autogen-tutorial/README.md
@@ -77,7 +77,7 @@ Welcome to your journey through multi-agent AI systems! This tutorial explores h
 
 - repository: [`microsoft/autogen`](https://github.com/microsoft/autogen)
 - stars: about **58.6k**
-- latest release: [`python-v0.7.5`](https://github.com/microsoft/autogen/releases/tag/python-v0.7.5) (published 2025-09-30)
+- GitHub release reference: [`python-v0.7.5`](https://github.com/microsoft/autogen/releases/tag/python-v0.7.5) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/awslabs-mcp-tutorial/README.md
+++ b/tutorials/awslabs-mcp-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`awslabs/mcp`](https://github.com/awslabs/mcp)
 - stars: about **9.2k**
-- latest release: [`2026.05.20260529200555`](https://github.com/awslabs/mcp/releases/tag/2026.05.20260529200555) (published 2026-05-29)
+- GitHub release reference: [`2026.05.20260529200555`](https://github.com/awslabs/mcp/releases/tag/2026.05.20260529200555) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/beads-tutorial/README.md
+++ b/tutorials/beads-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`steveyegge/beads`](https://github.com/steveyegge/beads)
 - stars: about **24.3k**
-- latest release: [`v1.0.4`](https://github.com/steveyegge/beads/releases/tag/v1.0.4) (published 2026-05-09)
+- GitHub release reference: [`v1.0.4`](https://github.com/steveyegge/beads/releases/tag/v1.0.4) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/bentoml-tutorial/README.md
+++ b/tutorials/bentoml-tutorial/README.md
@@ -81,7 +81,7 @@ Welcome to your journey through production ML deployment! This tutorial explores
 
 - repository: [`bentoml/BentoML`](https://github.com/bentoml/BentoML)
 - stars: about **8.7k**
-- latest release: [`v1.4.39`](https://github.com/bentoml/BentoML/releases/tag/v1.4.39) (published 2026-05-07)
+- GitHub release reference: [`v1.4.39`](https://github.com/bentoml/BentoML/releases/tag/v1.4.39) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/bolt-diy-tutorial/README.md
+++ b/tutorials/bolt-diy-tutorial/README.md
@@ -27,7 +27,7 @@ Most bolt.diy guides stop at setup. This track is for engineers and teams that w
 
 - repository: [`stackblitz-labs/bolt.diy`](https://github.com/stackblitz-labs/bolt.diy)
 - stars: about **19.4k**
-- latest release: [`v1.0.0`](https://github.com/stackblitz-labs/bolt.diy/releases/tag/v1.0.0) (published 2025-05-12)
+- GitHub release reference: [`v1.0.0`](https://github.com/stackblitz-labs/bolt.diy/releases/tag/v1.0.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/botpress-tutorial/README.md
+++ b/tutorials/botpress-tutorial/README.md
@@ -45,7 +45,7 @@ This comprehensive tutorial will guide you through Botpress, a powerful open sou
 
 - repository: [`botpress/botpress`](https://github.com/botpress/botpress)
 - stars: about **14.7k**
-- latest release: [`v12.30.9`](https://github.com/botpress/botpress/releases/tag/v12.30.9) (published 2023-06-22)
+- GitHub release reference: [`v12.30.9`](https://github.com/botpress/botpress/releases/tag/v12.30.9) (checked 2026-06-02; release metadata on GitHub)
 
 ## 📚 Tutorial Chapters
 

--- a/tutorials/browser-use-tutorial/README.md
+++ b/tutorials/browser-use-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`browser-use/browser-use`](https://github.com/browser-use/browser-use)
 - stars: about **96.5k**
-- latest release: [`0.12.9`](https://github.com/browser-use/browser-use/releases/tag/0.12.9) (published 2026-05-26)
+- GitHub release reference: [`0.12.9`](https://github.com/browser-use/browser-use/releases/tag/0.12.9) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/chatbox-tutorial/README.md
+++ b/tutorials/chatbox-tutorial/README.md
@@ -75,7 +75,7 @@ Welcome to your journey through modern AI chat interface development! This tutor
 
 - repository: [`Bin-Huang/chatbox`](https://github.com/Bin-Huang/chatbox)
 - stars: about **40.2k**
-- latest release: [`v1.20.3`](https://github.com/Bin-Huang/chatbox/releases/tag/v1.20.3) (published 2026-05-31)
+- GitHub release reference: [`v1.20.3`](https://github.com/Bin-Huang/chatbox/releases/tag/v1.20.3) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/cherry-studio-tutorial/README.md
+++ b/tutorials/cherry-studio-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`CherryHQ/cherry-studio`](https://github.com/CherryHQ/cherry-studio)
 - stars: about **46.7k**
-- latest release: [`v1.9.8`](https://github.com/CherryHQ/cherry-studio/releases/tag/v1.9.8) (published 2026-05-31)
+- GitHub release reference: [`v1.9.8`](https://github.com/CherryHQ/cherry-studio/releases/tag/v1.9.8) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/chroma-tutorial/README.md
+++ b/tutorials/chroma-tutorial/README.md
@@ -76,7 +76,7 @@ Welcome to your journey through AI-native vector databases! This tutorial explor
 
 - repository: [`chroma-core/chroma`](https://github.com/chroma-core/chroma)
 - stars: about **28.2k**
-- latest release: [`1.5.9`](https://github.com/chroma-core/chroma/releases/tag/1.5.9) (published 2026-05-05)
+- GitHub release reference: [`1.5.9`](https://github.com/chroma-core/chroma/releases/tag/1.5.9) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/chrome-devtools-mcp-tutorial/README.md
+++ b/tutorials/chrome-devtools-mcp-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`ChromeDevTools/chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp)
 - stars: about **42.5k**
-- latest release: [`chrome-devtools-mcp-v1.1.1`](https://github.com/ChromeDevTools/chrome-devtools-mcp/releases/tag/chrome-devtools-mcp-v1.1.1) (published 2026-05-27)
+- GitHub release reference: [`chrome-devtools-mcp-v1.1.1`](https://github.com/ChromeDevTools/chrome-devtools-mcp/releases/tag/chrome-devtools-mcp-v1.1.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/cipher-tutorial/README.md
+++ b/tutorials/cipher-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`campfirein/cipher`](https://github.com/campfirein/cipher)
 - stars: about **4.8k**
-- latest release: [`v3.16.1`](https://github.com/campfirein/cipher/releases/tag/v3.16.1) (published 2026-05-27)
+- GitHub release reference: [`v3.16.1`](https://github.com/campfirein/cipher/releases/tag/v3.16.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/claude-code-tutorial/README.md
+++ b/tutorials/claude-code-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`anthropics/claude-code`](https://github.com/anthropics/claude-code)
 - stars: about **129k**
-- latest release: [`v2.1.159`](https://github.com/anthropics/claude-code/releases/tag/v2.1.159) (published 2026-05-31)
+- GitHub release reference: [`v2.1.159`](https://github.com/anthropics/claude-code/releases/tag/v2.1.159) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/claude-flow-tutorial/README.md
+++ b/tutorials/claude-flow-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`ruvnet/claude-flow`](https://github.com/ruvnet/claude-flow)
 - stars: about **57.1k**
-- latest release: [`v3.10.31`](https://github.com/ruvnet/claude-flow/releases/tag/v3.10.31) (published 2026-05-31)
+- GitHub release reference: [`v3.10.31`](https://github.com/ruvnet/claude-flow/releases/tag/v3.10.31) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/claude-mem-tutorial/README.md
+++ b/tutorials/claude-mem-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`thedotmack/claude-mem`](https://github.com/thedotmack/claude-mem)
 - stars: about **80k**
-- latest release: [`v13.4.0`](https://github.com/thedotmack/claude-mem/releases/tag/v13.4.0) (published 2026-05-29)
+- GitHub release reference: [`v13.4.0`](https://github.com/thedotmack/claude-mem/releases/tag/v13.4.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/claude-squad-tutorial/README.md
+++ b/tutorials/claude-squad-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`smtg-ai/claude-squad`](https://github.com/smtg-ai/claude-squad)
 - stars: about **7.7k**
-- latest release: [`v1.0.18`](https://github.com/smtg-ai/claude-squad/releases/tag/v1.0.18) (published 2026-05-23)
+- GitHub release reference: [`v1.0.18`](https://github.com/smtg-ai/claude-squad/releases/tag/v1.0.18) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/claude-task-master-tutorial/README.md
+++ b/tutorials/claude-task-master-tutorial/README.md
@@ -77,7 +77,7 @@ Welcome to your journey through AI-powered task management! This tutorial explor
 
 - repository: [`eyaltoledano/claude-task-master`](https://github.com/eyaltoledano/claude-task-master)
 - stars: about **27.3k**
-- latest release: [`task-master-ai@0.43.1`](https://github.com/eyaltoledano/claude-task-master/releases/tag/task-master-ai@0.43.1) (published 2026-03-31)
+- GitHub release reference: [`task-master-ai@0.43.1`](https://github.com/eyaltoledano/claude-task-master/releases/tag/task-master-ai@0.43.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/clickhouse-tutorial/README.md
+++ b/tutorials/clickhouse-tutorial/README.md
@@ -81,7 +81,7 @@ Welcome to your journey through high-performance analytical databases! This tuto
 
 - repository: [`ClickHouse/ClickHouse`](https://github.com/ClickHouse/ClickHouse)
 - stars: about **47.7k**
-- latest release: [`v26.3.12.3-lts`](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.3.12.3-lts) (published 2026-05-22)
+- GitHub release reference: [`v26.3.12.3-lts`](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.3.12.3-lts) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/cline-tutorial/README.md
+++ b/tutorials/cline-tutorial/README.md
@@ -29,7 +29,7 @@ This tutorial focuses on those outcomes.
 
 - repository: [`cline/cline`](https://github.com/cline/cline)
 - stars: about **62.6k**
-- latest release: [`v3.86.1`](https://github.com/cline/cline/releases/tag/v3.86.1) (published 2026-06-01)
+- GitHub release reference: [`v3.86.1`](https://github.com/cline/cline/releases/tag/v3.86.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Cline Operating Model
 

--- a/tutorials/codemachine-cli-tutorial/README.md
+++ b/tutorials/codemachine-cli-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`moazbuilds/CodeMachine-CLI`](https://github.com/moazbuilds/CodeMachine-CLI)
 - stars: about **2.5k**
-- latest release: [`v0.8.0`](https://github.com/moazbuilds/CodeMachine-CLI/releases/tag/v0.8.0) (published 2026-02-02)
+- GitHub release reference: [`v0.8.0`](https://github.com/moazbuilds/CodeMachine-CLI/releases/tag/v0.8.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/codex-analysis-tutorial/README.md
+++ b/tutorials/codex-analysis-tutorial/README.md
@@ -28,7 +28,7 @@ This track focuses on:
 
 - repository: [`microsoft/TypeScript`](https://github.com/microsoft/TypeScript)
 - stars: about **109k**
-- latest release: [`v6.0.3`](https://github.com/microsoft/TypeScript/releases/tag/v6.0.3) (published 2026-04-16)
+- GitHub release reference: [`v6.0.3`](https://github.com/microsoft/TypeScript/releases/tag/v6.0.3) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/codex-cli-tutorial/README.md
+++ b/tutorials/codex-cli-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`openai/codex`](https://github.com/openai/codex)
 - stars: about **87.5k**
-- latest release: [`rust-v0.135.0`](https://github.com/openai/codex/releases/tag/rust-v0.135.0) (published 2026-05-28)
+- GitHub release reference: [`rust-v0.135.0`](https://github.com/openai/codex/releases/tag/rust-v0.135.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/comfyui-tutorial/README.md
+++ b/tutorials/comfyui-tutorial/README.md
@@ -82,7 +82,7 @@ Welcome to your journey through advanced AI image generation! This tutorial expl
 
 - repository: [`comfyanonymous/ComfyUI`](https://github.com/comfyanonymous/ComfyUI)
 - stars: about **115k**
-- latest release: [`v0.22.0`](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.22.0) (published 2026-05-20)
+- GitHub release reference: [`v0.22.0`](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.22.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/composio-tutorial/README.md
+++ b/tutorials/composio-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`ComposioHQ/composio`](https://github.com/ComposioHQ/composio)
 - stars: about **28.6k**
-- latest release: [`@composio/claude-agent-sdk@0.9.2`](https://github.com/ComposioHQ/composio/releases/tag/@composio/claude-agent-sdk@0.9.2) (published 2026-05-13)
+- GitHub release reference: [`@composio/claude-agent-sdk@0.9.2`](https://github.com/ComposioHQ/composio/releases/tag/@composio/claude-agent-sdk@0.9.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/compound-engineering-plugin-tutorial/README.md
+++ b/tutorials/compound-engineering-plugin-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`EveryInc/compound-engineering-plugin`](https://github.com/EveryInc/compound-engineering-plugin)
 - stars: about **18.9k**
-- latest release: [`compound-engineering-v3.9.4`](https://github.com/EveryInc/compound-engineering-plugin/releases/tag/compound-engineering-v3.9.4) (published 2026-05-31)
+- GitHub release reference: [`compound-engineering-v3.9.4`](https://github.com/EveryInc/compound-engineering-plugin/releases/tag/compound-engineering-v3.9.4) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/context7-tutorial/README.md
+++ b/tutorials/context7-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`upstash/context7`](https://github.com/upstash/context7)
 - stars: about **56.5k**
-- latest release: [`@upstash/context7-pi@0.1.0`](https://github.com/upstash/context7/releases/tag/@upstash/context7-pi@0.1.0) (published 2026-05-25)
+- GitHub release reference: [`@upstash/context7-pi@0.1.0`](https://github.com/upstash/context7/releases/tag/@upstash/context7-pi@0.1.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/continue-tutorial/README.md
+++ b/tutorials/continue-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`continuedev/continue`](https://github.com/continuedev/continue)
 - stars: about **33.5k**
-- latest release: [`v1.2.22-vscode`](https://github.com/continuedev/continue/releases/tag/v1.2.22-vscode) (published 2026-03-27)
+- GitHub release reference: [`v1.2.22-vscode`](https://github.com/continuedev/continue/releases/tag/v1.2.22-vscode) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/copilot-cli-tutorial/README.md
+++ b/tutorials/copilot-cli-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`github/copilot-cli`](https://github.com/github/copilot-cli)
 - stars: about **10.7k**
-- latest release: [`v1.0.56`](https://github.com/github/copilot-cli/releases/tag/v1.0.56) (published 2026-05-29)
+- GitHub release reference: [`v1.0.56`](https://github.com/github/copilot-cli/releases/tag/v1.0.56) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/copilotkit-tutorial/README.md
+++ b/tutorials/copilotkit-tutorial/README.md
@@ -78,7 +78,7 @@ flowchart TD
 
 - repository: [`CopilotKit/CopilotKit`](https://github.com/CopilotKit/CopilotKit)
 - stars: about **31.9k**
-- latest release: [`v1.59.2`](https://github.com/CopilotKit/CopilotKit/releases/tag/v1.59.2) (published 2026-05-30)
+- GitHub release reference: [`v1.59.2`](https://github.com/CopilotKit/CopilotKit/releases/tag/v1.59.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## What's New in 2025
 

--- a/tutorials/crawl4ai-tutorial/README.md
+++ b/tutorials/crawl4ai-tutorial/README.md
@@ -33,7 +33,7 @@ This track focuses on:
 
 - repository: [`unclecode/crawl4ai`](https://github.com/unclecode/crawl4ai)
 - stars: about **67.5k**
-- latest release: [`v0.8.5`](https://github.com/unclecode/crawl4ai/releases/tag/v0.8.5) (published 2026-03-18)
+- GitHub release reference: [`v0.8.5`](https://github.com/unclecode/crawl4ai/releases/tag/v0.8.5) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/create-python-server-tutorial/README.md
+++ b/tutorials/create-python-server-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/create-python-server`](https://github.com/modelcontextprotocol/create-python-server)
 - stars: about **478**
-- latest release: [`v1.0.5`](https://github.com/modelcontextprotocol/create-python-server/releases/tag/v1.0.5) (published 2024-11-24)
+- GitHub release reference: [`v1.0.5`](https://github.com/modelcontextprotocol/create-python-server/releases/tag/v1.0.5) (checked 2026-06-02; release metadata on GitHub)
 - status: **archived**
 
 ## Mental Model

--- a/tutorials/create-typescript-server-tutorial/README.md
+++ b/tutorials/create-typescript-server-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/create-typescript-server`](https://github.com/modelcontextprotocol/create-typescript-server)
 - stars: about **171**
-- latest release: [`0.3.1`](https://github.com/modelcontextprotocol/create-typescript-server/releases/tag/0.3.1) (published 2024-11-25)
+- GitHub release reference: [`0.3.1`](https://github.com/modelcontextprotocol/create-typescript-server/releases/tag/0.3.1) (checked 2026-06-02; release metadata on GitHub)
 - status: **archived**
 
 ## Mental Model

--- a/tutorials/crewai-tutorial/README.md
+++ b/tutorials/crewai-tutorial/README.md
@@ -76,7 +76,7 @@ Welcome to your journey through collaborative AI agent teams! This tutorial expl
 
 - repository: [`crewAIInc/crewAI`](https://github.com/crewAIInc/crewAI)
 - stars: about **52.6k**
-- latest release: [`1.14.6`](https://github.com/crewAIInc/crewAI/releases/tag/1.14.6) (published 2026-05-28)
+- GitHub release reference: [`1.14.6`](https://github.com/crewAIInc/crewAI/releases/tag/1.14.6) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/crush-tutorial/README.md
+++ b/tutorials/crush-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`charmbracelet/crush`](https://github.com/charmbracelet/crush)
 - stars: about **24.9k**
-- latest release: [`v0.74.1`](https://github.com/charmbracelet/crush/releases/tag/v0.74.1) (published 2026-05-29)
+- GitHub release reference: [`v0.74.1`](https://github.com/charmbracelet/crush/releases/tag/v0.74.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/daytona-tutorial/README.md
+++ b/tutorials/daytona-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`daytonaio/daytona`](https://github.com/daytonaio/daytona)
 - stars: about **72.5k**
-- latest release: [`v0.183.0`](https://github.com/daytonaio/daytona/releases/tag/v0.183.0) (published 2026-05-29)
+- GitHub release reference: [`v0.183.0`](https://github.com/daytonaio/daytona/releases/tag/v0.183.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/dify-tutorial/README.md
+++ b/tutorials/dify-tutorial/README.md
@@ -136,7 +136,7 @@ Ready to begin? Start with [Chapter 1: System Overview](01-system-overview.md).
 
 - repository: [`langgenius/dify`](https://github.com/langgenius/dify)
 - stars: about **143k**
-- latest release: [`1.14.2`](https://github.com/langgenius/dify/releases/tag/1.14.2) (published 2026-05-19)
+- GitHub release reference: [`1.14.2`](https://github.com/langgenius/dify/releases/tag/1.14.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/dspy-tutorial/README.md
+++ b/tutorials/dspy-tutorial/README.md
@@ -72,7 +72,7 @@ flowchart TD
 
 - repository: [`stanfordnlp/dspy`](https://github.com/stanfordnlp/dspy)
 - stars: about **34.8k**
-- latest release: [`3.2.1`](https://github.com/stanfordnlp/dspy/releases/tag/3.2.1) (published 2026-05-05)
+- GitHub release reference: [`3.2.1`](https://github.com/stanfordnlp/dspy/releases/tag/3.2.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Core Concepts
 

--- a/tutorials/dyad-tutorial/README.md
+++ b/tutorials/dyad-tutorial/README.md
@@ -27,7 +27,7 @@ Dyad is one of the fastest-moving local-first vibe-coding tools. To use it effec
 
 - repository: [`dyad-sh/dyad`](https://github.com/dyad-sh/dyad)
 - stars: about **20.5k**
-- latest release: [`v1.1.0`](https://github.com/dyad-sh/dyad/releases/tag/v1.1.0) (published 2026-05-27)
+- GitHub release reference: [`v1.1.0`](https://github.com/dyad-sh/dyad/releases/tag/v1.1.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/e2b-tutorial/README.md
+++ b/tutorials/e2b-tutorial/README.md
@@ -32,7 +32,7 @@ This track focuses on:
 
 - repository: [`e2b-dev/E2B`](https://github.com/e2b-dev/E2B)
 - stars: about **12.4k**
-- latest release: [`@e2b/python-sdk@2.25.1`](https://github.com/e2b-dev/E2B/releases/tag/@e2b/python-sdk@2.25.1) (published 2026-05-29)
+- GitHub release reference: [`@e2b/python-sdk@2.25.1`](https://github.com/e2b-dev/E2B/releases/tag/@e2b/python-sdk@2.25.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/elizaos-tutorial/README.md
+++ b/tutorials/elizaos-tutorial/README.md
@@ -43,7 +43,7 @@ ElizaOS is an open-source framework for building, deploying, and managing autono
 
 - repository: [`elizaOS/eliza`](https://github.com/elizaOS/eliza)
 - stars: about **18.5k**
-- latest release: [`v2.0.3`](https://github.com/elizaOS/eliza/releases/tag/v2.0.3) (published 2026-05-20)
+- GitHub release reference: [`v2.0.3`](https://github.com/elizaOS/eliza/releases/tag/v2.0.3) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/everything-claude-code-tutorial/README.md
+++ b/tutorials/everything-claude-code-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
 - stars: about **201k**
-- latest release: [`v1.10.0`](https://github.com/affaan-m/everything-claude-code/releases/tag/v1.10.0) (published 2026-04-05)
+- GitHub release reference: [`v1.10.0`](https://github.com/affaan-m/everything-claude-code/releases/tag/v1.10.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/fabric-tutorial/README.md
+++ b/tutorials/fabric-tutorial/README.md
@@ -50,7 +50,7 @@ This track focuses on:
 
 - repository: [`danielmiessler/fabric`](https://github.com/danielmiessler/fabric)
 - stars: about **41.9k**
-- latest release: [`v1.4.453`](https://github.com/danielmiessler/fabric/releases/tag/v1.4.453) (published 2026-05-28)
+- GitHub release reference: [`v1.4.453`](https://github.com/danielmiessler/fabric/releases/tag/v1.4.453) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/fastmcp-tutorial/README.md
+++ b/tutorials/fastmcp-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`jlowin/fastmcp`](https://github.com/jlowin/fastmcp)
 - stars: about **25.4k**
-- latest release: [`v3.3.1`](https://github.com/jlowin/fastmcp/releases/tag/v3.3.1) (published 2026-05-15)
+- GitHub release reference: [`v3.3.1`](https://github.com/jlowin/fastmcp/releases/tag/v3.3.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/figma-context-mcp-tutorial/README.md
+++ b/tutorials/figma-context-mcp-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`GLips/Figma-Context-MCP`](https://github.com/GLips/Figma-Context-MCP)
 - stars: about **14.9k**
-- latest release: [`v0.12.0`](https://github.com/GLips/Figma-Context-MCP/releases/tag/v0.12.0) (published 2026-05-27)
+- GitHub release reference: [`v0.12.0`](https://github.com/GLips/Figma-Context-MCP/releases/tag/v0.12.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/firecrawl-mcp-server-tutorial/README.md
+++ b/tutorials/firecrawl-mcp-server-tutorial/README.md
@@ -30,7 +30,7 @@ This track focuses on:
 
 - repository: [`firecrawl/firecrawl-mcp-server`](https://github.com/firecrawl/firecrawl-mcp-server)
 - stars: about **6.5k**
-- latest release: [`v3.2.1`](https://github.com/firecrawl/firecrawl-mcp-server/releases/tag/v3.2.1) (published 2025-09-26)
+- GitHub release reference: [`v3.2.1`](https://github.com/firecrawl/firecrawl-mcp-server/releases/tag/v3.2.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/firecrawl-tutorial/README.md
+++ b/tutorials/firecrawl-tutorial/README.md
@@ -73,7 +73,7 @@ Welcome to your journey through web scraping and data extraction for AI applicat
 
 - repository: [`mendableai/firecrawl`](https://github.com/mendableai/firecrawl)
 - stars: about **127k**
-- latest release: [`v2.10`](https://github.com/mendableai/firecrawl/releases/tag/v2.10) (published 2026-05-15)
+- GitHub release reference: [`v2.10`](https://github.com/mendableai/firecrawl/releases/tag/v2.10) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/flowise-tutorial/README.md
+++ b/tutorials/flowise-tutorial/README.md
@@ -126,7 +126,7 @@ Ready to begin? Start with [Chapter 1: System Overview](01-system-overview.md).
 
 - repository: [`FlowiseAI/Flowise`](https://github.com/FlowiseAI/Flowise)
 - stars: about **53.2k**
-- latest release: [`flowise@3.1.2`](https://github.com/FlowiseAI/Flowise/releases/tag/flowise@3.1.2) (published 2026-04-14)
+- GitHub release reference: [`flowise@3.1.2`](https://github.com/FlowiseAI/Flowise/releases/tag/flowise@3.1.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/gemini-cli-tutorial/README.md
+++ b/tutorials/gemini-cli-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`google-gemini/gemini-cli`](https://github.com/google-gemini/gemini-cli)
 - stars: about **105k**
-- latest release: [`v0.44.1`](https://github.com/google-gemini/gemini-cli/releases/tag/v0.44.1) (published 2026-05-28)
+- GitHub release reference: [`v0.44.1`](https://github.com/google-gemini/gemini-cli/releases/tag/v0.44.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/genai-toolbox-tutorial/README.md
+++ b/tutorials/genai-toolbox-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`googleapis/genai-toolbox`](https://github.com/googleapis/genai-toolbox)
 - stars: about **15.4k**
-- latest release: [`v1.3.0`](https://github.com/googleapis/genai-toolbox/releases/tag/v1.3.0) (published 2026-05-21)
+- GitHub release reference: [`v1.3.0`](https://github.com/googleapis/genai-toolbox/releases/tag/v1.3.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/github-mcp-server-tutorial/README.md
+++ b/tutorials/github-mcp-server-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`github/github-mcp-server`](https://github.com/github/github-mcp-server)
 - stars: about **30.3k**
-- latest release: [`v1.1.2`](https://github.com/github/github-mcp-server/releases/tag/v1.1.2) (published 2026-05-29)
+- GitHub release reference: [`v1.1.2`](https://github.com/github/github-mcp-server/releases/tag/v1.1.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/goose-tutorial/README.md
+++ b/tutorials/goose-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`block/goose`](https://github.com/block/goose)
 - stars: about **46.1k**
-- latest release: [`v1.36.0`](https://github.com/block/goose/releases/tag/v1.36.0) (published 2026-05-27)
+- GitHub release reference: [`v1.36.0`](https://github.com/block/goose/releases/tag/v1.36.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/gptme-tutorial/README.md
+++ b/tutorials/gptme-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`gptme/gptme`](https://github.com/gptme/gptme)
 - stars: about **4.3k**
-- latest release: [`v0.31.0`](https://github.com/gptme/gptme/releases/tag/v0.31.0) (published 2025-12-15)
+- GitHub release reference: [`v0.31.0`](https://github.com/gptme/gptme/releases/tag/v0.31.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/hapi-tutorial/README.md
+++ b/tutorials/hapi-tutorial/README.md
@@ -32,7 +32,7 @@ HAPI wraps existing coding agents and adds a hub/web control plane so sessions c
 
 - repository: [`tiann/hapi`](https://github.com/tiann/hapi)
 - stars: about **4.2k**
-- latest release: [`v0.19.0`](https://github.com/tiann/hapi/releases/tag/v0.19.0) (published 2026-06-01)
+- GitHub release reference: [`v0.19.0`](https://github.com/tiann/hapi/releases/tag/v0.19.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/haystack-tutorial/README.md
+++ b/tutorials/haystack-tutorial/README.md
@@ -42,7 +42,7 @@ Haystack is an open-source LLM framework by deepset for building composable AI p
 
 - repository: [`deepset-ai/haystack`](https://github.com/deepset-ai/haystack)
 - stars: about **25.4k**
-- latest release: [`v2.29.0`](https://github.com/deepset-ai/haystack/releases/tag/v2.29.0) (published 2026-05-12)
+- GitHub release reference: [`v2.29.0`](https://github.com/deepset-ai/haystack/releases/tag/v2.29.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/hermes-agent-tutorial/README.md
+++ b/tutorials/hermes-agent-tutorial/README.md
@@ -36,7 +36,7 @@ Unlike ephemeral chatbot wrappers, Hermes is built around three design principle
 
 - repository: [`nousresearch/hermes-agent`](https://github.com/nousresearch/hermes-agent)
 - stars: about **175k**
-- latest release: [`v2026.5.29.2`](https://github.com/nousresearch/hermes-agent/releases/tag/v2026.5.29.2) (published 2026-05-29)
+- GitHub release reference: [`v2026.5.29.2`](https://github.com/nousresearch/hermes-agent/releases/tag/v2026.5.29.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Who Should Read This Tutorial
 

--- a/tutorials/huggingface-tutorial/README.md
+++ b/tutorials/huggingface-tutorial/README.md
@@ -77,7 +77,7 @@ Welcome to your journey through the HuggingFace Transformers ecosystem! This tut
 
 - repository: [`huggingface/transformers`](https://github.com/huggingface/transformers)
 - stars: about **161k**
-- latest release: [`v5.9.0`](https://github.com/huggingface/transformers/releases/tag/v5.9.0) (published 2026-05-20)
+- GitHub release reference: [`v5.9.0`](https://github.com/huggingface/transformers/releases/tag/v5.9.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/humanlayer-tutorial/README.md
+++ b/tutorials/humanlayer-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`humanlayer/humanlayer`](https://github.com/humanlayer/humanlayer)
 - stars: about **10.9k**
-- latest release: [`pro-0.20.0`](https://github.com/humanlayer/humanlayer/releases/tag/pro-0.20.0) (published 2025-12-23)
+- GitHub release reference: [`pro-0.20.0`](https://github.com/humanlayer/humanlayer/releases/tag/pro-0.20.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/instructor-tutorial/README.md
+++ b/tutorials/instructor-tutorial/README.md
@@ -73,7 +73,7 @@ flowchart LR
 
 - repository: [`instructor-ai/instructor`](https://github.com/instructor-ai/instructor)
 - stars: about **13.1k**
-- latest release: [`v1.15.1`](https://github.com/instructor-ai/instructor/releases/tag/v1.15.1) (published 2026-04-03)
+- GitHub release reference: [`v1.15.1`](https://github.com/instructor-ai/instructor/releases/tag/v1.15.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/khoj-tutorial/README.md
+++ b/tutorials/khoj-tutorial/README.md
@@ -42,7 +42,7 @@ Khoj is an open-source AI personal assistant that transforms your scattered note
 
 - repository: [`khoj-ai/khoj`](https://github.com/khoj-ai/khoj)
 - stars: about **34.8k**
-- latest release: [`2.0.0-beta.28`](https://github.com/khoj-ai/khoj/releases/tag/2.0.0-beta.28) (published 2026-03-26)
+- GitHub release reference: [`2.0.0-beta.28`](https://github.com/khoj-ai/khoj/releases/tag/2.0.0-beta.28) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/kilocode-tutorial/README.md
+++ b/tutorials/kilocode-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`Kilo-Org/kilocode`](https://github.com/Kilo-Org/kilocode)
 - stars: about **19.7k**
-- latest release: [`v7.3.16`](https://github.com/Kilo-Org/kilocode/releases/tag/v7.3.16) (published 2026-05-28)
+- GitHub release reference: [`v7.3.16`](https://github.com/Kilo-Org/kilocode/releases/tag/v7.3.16) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/kimi-cli-tutorial/README.md
+++ b/tutorials/kimi-cli-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`MoonshotAI/kimi-cli`](https://github.com/MoonshotAI/kimi-cli)
 - stars: about **8.8k**
-- latest release: [`1.46.0`](https://github.com/MoonshotAI/kimi-cli/releases/tag/1.46.0) (published 2026-05-29)
+- GitHub release reference: [`1.46.0`](https://github.com/MoonshotAI/kimi-cli/releases/tag/1.46.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/kubernetes-operator-tutorial/README.md
+++ b/tutorials/kubernetes-operator-tutorial/README.md
@@ -75,7 +75,7 @@ flowchart TD
 
 - repository: [`operator-framework/operator-sdk`](https://github.com/operator-framework/operator-sdk)
 - stars: about **7.6k**
-- latest release: [`v1.42.2`](https://github.com/operator-framework/operator-sdk/releases/tag/v1.42.2) (published 2026-03-19)
+- GitHub release reference: [`v1.42.2`](https://github.com/operator-framework/operator-sdk/releases/tag/v1.42.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Core Operator Concepts
 

--- a/tutorials/lancedb-tutorial/README.md
+++ b/tutorials/lancedb-tutorial/README.md
@@ -90,7 +90,7 @@ flowchart TD
 
 - repository: [`lancedb/lancedb`](https://github.com/lancedb/lancedb)
 - stars: about **10.5k**
-- latest release: [`python-v0.33.0`](https://github.com/lancedb/lancedb/releases/tag/python-v0.33.0) (published 2026-05-28)
+- GitHub release reference: [`python-v0.33.0`](https://github.com/lancedb/lancedb/releases/tag/python-v0.33.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/langchain-architecture-tutorial/README.md
+++ b/tutorials/langchain-architecture-tutorial/README.md
@@ -91,7 +91,7 @@ This guide is designed for developers who already have working experience with L
 
 - repository: [`langchain-ai/langchain`](https://github.com/langchain-ai/langchain)
 - stars: about **138k**
-- latest release: [`langchain-core==1.4.0`](https://github.com/langchain-ai/langchain/releases/tag/langchain-core==1.4.0) (published 2026-05-11)
+- GitHub release reference: [`langchain-core==1.4.0`](https://github.com/langchain-ai/langchain/releases/tag/langchain-core==1.4.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/langchain-tutorial/README.md
+++ b/tutorials/langchain-tutorial/README.md
@@ -71,7 +71,7 @@ Welcome to your journey through LangChain! This tutorial is structured to take y
 
 - repository: [`langchain-ai/langchain`](https://github.com/langchain-ai/langchain)
 - stars: about **138k**
-- latest release: [`langchain-core==1.4.0`](https://github.com/langchain-ai/langchain/releases/tag/langchain-core==1.4.0) (published 2026-05-11)
+- GitHub release reference: [`langchain-core==1.4.0`](https://github.com/langchain-ai/langchain/releases/tag/langchain-core==1.4.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/langflow-tutorial/README.md
+++ b/tutorials/langflow-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`langflow-ai/langflow`](https://github.com/langflow-ai/langflow)
 - stars: about **149k**
-- latest release: [`1.9.5`](https://github.com/langflow-ai/langflow/releases/tag/1.9.5) (published 2026-05-29)
+- GitHub release reference: [`1.9.5`](https://github.com/langflow-ai/langflow/releases/tag/1.9.5) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/langfuse-tutorial/README.md
+++ b/tutorials/langfuse-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`langfuse/langfuse`](https://github.com/langfuse/langfuse)
 - stars: about **28.3k**
-- latest release: [`v3.177.0`](https://github.com/langfuse/langfuse/releases/tag/v3.177.0) (published 2026-06-01)
+- GitHub release reference: [`v3.177.0`](https://github.com/langfuse/langfuse/releases/tag/v3.177.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/langgraph-tutorial/README.md
+++ b/tutorials/langgraph-tutorial/README.md
@@ -77,7 +77,7 @@ Welcome to your journey through stateful multi-actor applications! This tutorial
 
 - repository: [`langchain-ai/langgraph`](https://github.com/langchain-ai/langgraph)
 - stars: about **33.5k**
-- latest release: [`sdk==0.4.0`](https://github.com/langchain-ai/langgraph/releases/tag/sdk==0.4.0) (published 2026-05-28)
+- GitHub release reference: [`sdk==0.4.0`](https://github.com/langchain-ai/langgraph/releases/tag/sdk==0.4.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/letta-tutorial/README.md
+++ b/tutorials/letta-tutorial/README.md
@@ -85,7 +85,7 @@ flowchart TD
 
 - repository: [`letta-ai/letta`](https://github.com/letta-ai/letta)
 - stars: about **23.1k**
-- latest release: [`0.16.8`](https://github.com/letta-ai/letta/releases/tag/0.16.8) (published 2026-05-14)
+- GitHub release reference: [`0.16.8`](https://github.com/letta-ai/letta/releases/tag/0.16.8) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/litellm-tutorial/README.md
+++ b/tutorials/litellm-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`BerriAI/litellm`](https://github.com/BerriAI/litellm)
 - stars: about **48.9k**
-- latest release: [`v1.86.2`](https://github.com/BerriAI/litellm/releases/tag/v1.86.2) (published 2026-05-27)
+- GitHub release reference: [`v1.86.2`](https://github.com/BerriAI/litellm/releases/tag/v1.86.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/liveblocks-tutorial/README.md
+++ b/tutorials/liveblocks-tutorial/README.md
@@ -64,7 +64,7 @@ graph TB
 
 - repository: [`liveblocks/liveblocks`](https://github.com/liveblocks/liveblocks)
 - stars: about **4.6k**
-- latest release: [`v3.19.3`](https://github.com/liveblocks/liveblocks/releases/tag/v3.19.3) (published 2026-05-22)
+- GitHub release reference: [`v3.19.3`](https://github.com/liveblocks/liveblocks/releases/tag/v3.19.3) (checked 2026-06-02; release metadata on GitHub)
 
 ## Core Capabilities
 

--- a/tutorials/llama-cpp-tutorial/README.md
+++ b/tutorials/llama-cpp-tutorial/README.md
@@ -81,7 +81,7 @@ flowchart TD
 
 - repository: [`ggerganov/llama.cpp`](https://github.com/ggerganov/llama.cpp)
 - stars: about **114k**
-- latest release: [`b9444`](https://github.com/ggerganov/llama.cpp/releases/tag/b9444) (published 2026-05-31)
+- GitHub release reference: [`b9444`](https://github.com/ggerganov/llama.cpp/releases/tag/b9444) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/llama-factory-tutorial/README.md
+++ b/tutorials/llama-factory-tutorial/README.md
@@ -81,7 +81,7 @@ Welcome to your journey through unified LLM training! This tutorial explores how
 
 - repository: [`hiyouga/LLaMA-Factory`](https://github.com/hiyouga/LLaMA-Factory)
 - stars: about **71.8k**
-- latest release: [`v0.9.5`](https://github.com/hiyouga/LLaMA-Factory/releases/tag/v0.9.5) (published 2026-05-30)
+- GitHub release reference: [`v0.9.5`](https://github.com/hiyouga/LLaMA-Factory/releases/tag/v0.9.5) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/llamaindex-tutorial/README.md
+++ b/tutorials/llamaindex-tutorial/README.md
@@ -81,7 +81,7 @@ Welcome to your journey through advanced RAG systems and data frameworks! This t
 
 - repository: [`run-llama/llama_index`](https://github.com/run-llama/llama_index)
 - stars: about **49.8k**
-- latest release: [`v0.14.22`](https://github.com/run-llama/llama_index/releases/tag/v0.14.22) (published 2026-05-14)
+- GitHub release reference: [`v0.14.22`](https://github.com/run-llama/llama_index/releases/tag/v0.14.22) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/lobechat-tutorial/README.md
+++ b/tutorials/lobechat-tutorial/README.md
@@ -41,7 +41,7 @@ LobeChat is an open-source AI chat framework that enables you to build and deplo
 
 - repository: [`lobehub/lobe-chat`](https://github.com/lobehub/lobe-chat)
 - stars: about **78.1k**
-- latest release: [`v2.2.1`](https://github.com/lobehub/lobe-chat/releases/tag/v2.2.1) (published 2026-05-29)
+- GitHub release reference: [`v2.2.1`](https://github.com/lobehub/lobe-chat/releases/tag/v2.2.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/localai-tutorial/README.md
+++ b/tutorials/localai-tutorial/README.md
@@ -84,7 +84,7 @@ flowchart TD
 
 - repository: [`mudler/LocalAI`](https://github.com/mudler/LocalAI)
 - stars: about **46.6k**
-- latest release: [`v4.3.6`](https://github.com/mudler/LocalAI/releases/tag/v4.3.6) (published 2026-05-30)
+- GitHub release reference: [`v4.3.6`](https://github.com/mudler/LocalAI/releases/tag/v4.3.6) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/logseq-tutorial/README.md
+++ b/tutorials/logseq-tutorial/README.md
@@ -128,7 +128,7 @@ Ready to begin? Start with [Chapter 1: Knowledge Management Principles](01-knowl
 
 - repository: [`logseq/logseq`](https://github.com/logseq/logseq)
 - stars: about **43.2k**
-- latest release: [`0.10.15`](https://github.com/logseq/logseq/releases/tag/0.10.15) (published 2025-12-01)
+- GitHub release reference: [`0.10.15`](https://github.com/logseq/logseq/releases/tag/0.10.15) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/mastra-tutorial/README.md
+++ b/tutorials/mastra-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`mastra-ai/mastra`](https://github.com/mastra-ai/mastra)
 - stars: about **24.6k**
-- latest release: [`@mastra/core@1.37.0`](https://github.com/mastra-ai/mastra/releases/tag/@mastra/core@1.37.0) (published 2026-05-27)
+- GitHub release reference: [`@mastra/core@1.37.0`](https://github.com/mastra-ai/mastra/releases/tag/@mastra/core@1.37.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-chrome-tutorial/README.md
+++ b/tutorials/mcp-chrome-tutorial/README.md
@@ -30,7 +30,7 @@ This track focuses on:
 
 - repository: [`hangwin/mcp-chrome`](https://github.com/hangwin/mcp-chrome)
 - stars: about **11.8k**
-- latest release: [`v1.0.0`](https://github.com/hangwin/mcp-chrome/releases/tag/v1.0.0) (published 2025-12-29)
+- GitHub release reference: [`v1.0.0`](https://github.com/hangwin/mcp-chrome/releases/tag/v1.0.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-csharp-sdk-tutorial/README.md
+++ b/tutorials/mcp-csharp-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/csharp-sdk`](https://github.com/modelcontextprotocol/csharp-sdk)
 - stars: about **4.3k**
-- latest release: [`v1.3.0`](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v1.3.0) (published 2026-05-08)
+- GitHub release reference: [`v1.3.0`](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v1.3.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-ext-apps-tutorial/README.md
+++ b/tutorials/mcp-ext-apps-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/ext-apps`](https://github.com/modelcontextprotocol/ext-apps)
 - stars: about **2.3k**
-- latest release: [`v1.7.2`](https://github.com/modelcontextprotocol/ext-apps/releases/tag/v1.7.2) (published 2026-05-15)
+- GitHub release reference: [`v1.7.2`](https://github.com/modelcontextprotocol/ext-apps/releases/tag/v1.7.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-go-sdk-tutorial/README.md
+++ b/tutorials/mcp-go-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk)
 - stars: about **4.6k**
-- latest release: [`v1.6.1`](https://github.com/modelcontextprotocol/go-sdk/releases/tag/v1.6.1) (published 2026-05-22)
+- GitHub release reference: [`v1.6.1`](https://github.com/modelcontextprotocol/go-sdk/releases/tag/v1.6.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-inspector-tutorial/README.md
+++ b/tutorials/mcp-inspector-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector)
 - stars: about **9.9k**
-- latest release: [`0.21.2-hotfix-3`](https://github.com/modelcontextprotocol/inspector/releases/tag/0.21.2-hotfix-3) (published 2026-04-14)
+- GitHub release reference: [`0.21.2-hotfix-3`](https://github.com/modelcontextprotocol/inspector/releases/tag/0.21.2-hotfix-3) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-java-sdk-tutorial/README.md
+++ b/tutorials/mcp-java-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/java-sdk`](https://github.com/modelcontextprotocol/java-sdk)
 - stars: about **3.4k**
-- latest release: [`v1.1.2`](https://github.com/modelcontextprotocol/java-sdk/releases/tag/v1.1.2) (published 2026-04-25)
+- GitHub release reference: [`v1.1.2`](https://github.com/modelcontextprotocol/java-sdk/releases/tag/v1.1.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-kotlin-sdk-tutorial/README.md
+++ b/tutorials/mcp-kotlin-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/kotlin-sdk`](https://github.com/modelcontextprotocol/kotlin-sdk)
 - stars: about **1.4k**
-- latest release: [`0.12.0`](https://github.com/modelcontextprotocol/kotlin-sdk/releases/tag/0.12.0) (published 2026-04-29)
+- GitHub release reference: [`0.12.0`](https://github.com/modelcontextprotocol/kotlin-sdk/releases/tag/0.12.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-php-sdk-tutorial/README.md
+++ b/tutorials/mcp-php-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/php-sdk`](https://github.com/modelcontextprotocol/php-sdk)
 - stars: about **1.5k**
-- latest release: [`v0.5.0`](https://github.com/modelcontextprotocol/php-sdk/releases/tag/v0.5.0) (published 2026-04-26)
+- GitHub release reference: [`v0.5.0`](https://github.com/modelcontextprotocol/php-sdk/releases/tag/v0.5.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-python-sdk-tutorial/README.md
+++ b/tutorials/mcp-python-sdk-tutorial/README.md
@@ -45,7 +45,7 @@ The **Model Context Protocol (MCP) Python SDK** is the official Python implement
 
 - repository: [`modelcontextprotocol/python-sdk`](https://github.com/modelcontextprotocol/python-sdk)
 - stars: about **23.2k**
-- latest release: [`v1.27.2`](https://github.com/modelcontextprotocol/python-sdk/releases/tag/v1.27.2) (published 2026-05-29)
+- GitHub release reference: [`v1.27.2`](https://github.com/modelcontextprotocol/python-sdk/releases/tag/v1.27.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-registry-tutorial/README.md
+++ b/tutorials/mcp-registry-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/registry`](https://github.com/modelcontextprotocol/registry)
 - stars: about **6.9k**
-- latest release: [`v1.7.9`](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.9) (published 2026-05-12)
+- GitHub release reference: [`v1.7.9`](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.9) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-ruby-sdk-tutorial/README.md
+++ b/tutorials/mcp-ruby-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/ruby-sdk`](https://github.com/modelcontextprotocol/ruby-sdk)
 - stars: about **843**
-- latest release: [`v0.18.0`](https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v0.18.0) (published 2026-05-30)
+- GitHub release reference: [`v0.18.0`](https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v0.18.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-rust-sdk-tutorial/README.md
+++ b/tutorials/mcp-rust-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/rust-sdk`](https://github.com/modelcontextprotocol/rust-sdk)
 - stars: about **3.5k**
-- latest release: [`rmcp-v1.7.0`](https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v1.7.0) (published 2026-05-13)
+- GitHub release reference: [`rmcp-v1.7.0`](https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v1.7.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-servers-tutorial/README.md
+++ b/tutorials/mcp-servers-tutorial/README.md
@@ -114,7 +114,7 @@ Ready to begin? Start with [Chapter 1: Getting Started](01-getting-started.md).
 
 - repository: [`modelcontextprotocol/servers`](https://github.com/modelcontextprotocol/servers)
 - stars: about **86.6k**
-- latest release: [`2026.1.26`](https://github.com/modelcontextprotocol/servers/releases/tag/2026.1.26) (published 2026-01-27)
+- GitHub release reference: [`2026.1.26`](https://github.com/modelcontextprotocol/servers/releases/tag/2026.1.26) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/mcp-specification-tutorial/README.md
+++ b/tutorials/mcp-specification-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/modelcontextprotocol`](https://github.com/modelcontextprotocol/modelcontextprotocol)
 - stars: about **8.3k**
-- latest release: [`2025-11-25`](https://github.com/modelcontextprotocol/modelcontextprotocol/releases/tag/2025-11-25) (published 2025-11-25)
+- GitHub release reference: [`2025-11-25`](https://github.com/modelcontextprotocol/modelcontextprotocol/releases/tag/2025-11-25) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-swift-sdk-tutorial/README.md
+++ b/tutorials/mcp-swift-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/swift-sdk`](https://github.com/modelcontextprotocol/swift-sdk)
 - stars: about **1.4k**
-- latest release: [`0.12.1`](https://github.com/modelcontextprotocol/swift-sdk/releases/tag/0.12.1) (published 2026-05-07)
+- GitHub release reference: [`0.12.1`](https://github.com/modelcontextprotocol/swift-sdk/releases/tag/0.12.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-typescript-sdk-tutorial/README.md
+++ b/tutorials/mcp-typescript-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/typescript-sdk`](https://github.com/modelcontextprotocol/typescript-sdk)
 - stars: about **12.6k**
-- latest release: [`v1.29.0`](https://github.com/modelcontextprotocol/typescript-sdk/releases/tag/v1.29.0) (published 2026-03-30)
+- GitHub release reference: [`v1.29.0`](https://github.com/modelcontextprotocol/typescript-sdk/releases/tag/v1.29.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcp-use-tutorial/README.md
+++ b/tutorials/mcp-use-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`mcp-use/mcp-use`](https://github.com/mcp-use/mcp-use)
 - stars: about **10k**
-- latest release: [`python-v1.7.0`](https://github.com/mcp-use/mcp-use/releases/tag/python-v1.7.0) (published 2026-03-17)
+- GitHub release reference: [`python-v1.7.0`](https://github.com/mcp-use/mcp-use/releases/tag/python-v1.7.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mcpb-tutorial/README.md
+++ b/tutorials/mcpb-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`modelcontextprotocol/mcpb`](https://github.com/modelcontextprotocol/mcpb)
 - stars: about **1.9k**
-- latest release: [`v2.1.2`](https://github.com/modelcontextprotocol/mcpb/releases/tag/v2.1.2) (published 2025-12-04)
+- GitHub release reference: [`v2.1.2`](https://github.com/modelcontextprotocol/mcpb/releases/tag/v2.1.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/meilisearch-tutorial/README.md
+++ b/tutorials/meilisearch-tutorial/README.md
@@ -54,7 +54,7 @@ This comprehensive tutorial will guide you through Meilisearch, a powerful searc
 
 - repository: [`meilisearch/meilisearch`](https://github.com/meilisearch/meilisearch)
 - stars: about **57.9k**
-- latest release: [`v1.45.1`](https://github.com/meilisearch/meilisearch/releases/tag/v1.45.1) (published 2026-05-28)
+- GitHub release reference: [`v1.45.1`](https://github.com/meilisearch/meilisearch/releases/tag/v1.45.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## 📚 Tutorial Chapters
 

--- a/tutorials/mem0-tutorial/README.md
+++ b/tutorials/mem0-tutorial/README.md
@@ -79,7 +79,7 @@ Welcome to your journey through scalable AI memory systems! This tutorial explor
 
 - repository: [`mem0ai/mem0`](https://github.com/mem0ai/mem0)
 - stars: about **57.3k**
-- latest release: [`opencode-v0.1.2`](https://github.com/mem0ai/mem0/releases/tag/opencode-v0.1.2) (published 2026-06-01)
+- GitHub release reference: [`opencode-v0.1.2`](https://github.com/mem0ai/mem0/releases/tag/opencode-v0.1.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/metagpt-tutorial/README.md
+++ b/tutorials/metagpt-tutorial/README.md
@@ -31,7 +31,7 @@ This track focuses on:
 
 - repository: [`geekan/MetaGPT`](https://github.com/geekan/MetaGPT)
 - stars: about **68.5k**
-- latest release: [`v0.8.1`](https://github.com/geekan/MetaGPT/releases/tag/v0.8.1) (published 2024-04-22)
+- GitHub release reference: [`v0.8.1`](https://github.com/geekan/MetaGPT/releases/tag/v0.8.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mini-swe-agent-tutorial/README.md
+++ b/tutorials/mini-swe-agent-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`SWE-agent/mini-swe-agent`](https://github.com/SWE-agent/mini-swe-agent)
 - stars: about **4.8k**
-- latest release: [`v2.3.0`](https://github.com/SWE-agent/mini-swe-agent/releases/tag/v2.3.0) (published 2026-05-21)
+- GitHub release reference: [`v2.3.0`](https://github.com/SWE-agent/mini-swe-agent/releases/tag/v2.3.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/mistral-vibe-tutorial/README.md
+++ b/tutorials/mistral-vibe-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`mistralai/mistral-vibe`](https://github.com/mistralai/mistral-vibe)
 - stars: about **4.4k**
-- latest release: [`v2.13.0`](https://github.com/mistralai/mistral-vibe/releases/tag/v2.13.0) (published 2026-05-29)
+- GitHub release reference: [`v2.13.0`](https://github.com/mistralai/mistral-vibe/releases/tag/v2.13.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/n8n-ai-tutorial/README.md
+++ b/tutorials/n8n-ai-tutorial/README.md
@@ -80,7 +80,7 @@ flowchart LR
 
 - repository: [`n8n-io/n8n`](https://github.com/n8n-io/n8n)
 - stars: about **191k**
-- latest release: [`n8n@2.22.6`](https://github.com/n8n-io/n8n/releases/tag/n8n@2.22.6) (published 2026-06-01)
+- GitHub release reference: [`n8n@2.22.6`](https://github.com/n8n-io/n8n/releases/tag/n8n@2.22.6) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/n8n-mcp-tutorial/README.md
+++ b/tutorials/n8n-mcp-tutorial/README.md
@@ -41,7 +41,7 @@ This tutorial covers n8n's integration with the Model Context Protocol (MCP) —
 
 - repository: [`n8n-io/n8n`](https://github.com/n8n-io/n8n)
 - stars: about **191k**
-- latest release: [`n8n@2.22.6`](https://github.com/n8n-io/n8n/releases/tag/n8n@2.22.6) (published 2026-06-01)
+- GitHub release reference: [`n8n@2.22.6`](https://github.com/n8n-io/n8n/releases/tag/n8n@2.22.6) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/nanocoder-tutorial/README.md
+++ b/tutorials/nanocoder-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`Nano-Collective/nanocoder`](https://github.com/Nano-Collective/nanocoder)
 - stars: about **2k**
-- latest release: [`v1.27.0`](https://github.com/Nano-Collective/nanocoder/releases/tag/v1.27.0) (published 2026-05-26)
+- GitHub release reference: [`v1.27.0`](https://github.com/Nano-Collective/nanocoder/releases/tag/v1.27.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/nocodb-tutorial/README.md
+++ b/tutorials/nocodb-tutorial/README.md
@@ -128,7 +128,7 @@ Ready to begin? Start with [Chapter 1: System Overview](01-system-overview.md).
 
 - repository: [`nocodb/nocodb`](https://github.com/nocodb/nocodb)
 - stars: about **63.2k**
-- latest release: [`2026.05.2`](https://github.com/nocodb/nocodb/releases/tag/2026.05.2) (published 2026-05-27)
+- GitHub release reference: [`2026.05.2`](https://github.com/nocodb/nocodb/releases/tag/2026.05.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/obsidian-outliner-tutorial/README.md
+++ b/tutorials/obsidian-outliner-tutorial/README.md
@@ -118,7 +118,7 @@ Ready to begin? Start with [Chapter 1: Plugin Architecture](01-plugin-architectu
 
 - repository: [`vslinko/obsidian-outliner`](https://github.com/vslinko/obsidian-outliner)
 - stars: about **1.3k**
-- latest release: [`4.10.1`](https://github.com/vslinko/obsidian-outliner/releases/tag/4.10.1) (published 2026-05-27)
+- GitHub release reference: [`4.10.1`](https://github.com/vslinko/obsidian-outliner/releases/tag/4.10.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/ollama-tutorial/README.md
+++ b/tutorials/ollama-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`ollama/ollama`](https://github.com/ollama/ollama)
 - stars: about **173k**
-- latest release: [`v0.24.0`](https://github.com/ollama/ollama/releases/tag/v0.24.0) (published 2026-05-14)
+- GitHub release reference: [`v0.24.0`](https://github.com/ollama/ollama/releases/tag/v0.24.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/onlook-tutorial/README.md
+++ b/tutorials/onlook-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`onlook-dev/onlook`](https://github.com/onlook-dev/onlook)
 - stars: about **25.9k**
-- latest release: [`v0.2.32`](https://github.com/onlook-dev/onlook/releases/tag/v0.2.32) (published 2025-07-17)
+- GitHub release reference: [`v0.2.32`](https://github.com/onlook-dev/onlook/releases/tag/v0.2.32) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/opcode-tutorial/README.md
+++ b/tutorials/opcode-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`winfunc/opcode`](https://github.com/winfunc/opcode)
 - stars: about **22k**
-- latest release: [`v0.2.0`](https://github.com/winfunc/opcode/releases/tag/v0.2.0) (published 2025-08-31)
+- GitHub release reference: [`v0.2.0`](https://github.com/winfunc/opcode/releases/tag/v0.2.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/open-webui-tutorial/README.md
+++ b/tutorials/open-webui-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`open-webui/open-webui`](https://github.com/open-webui/open-webui)
 - stars: about **139k**
-- latest release: [`v0.9.5`](https://github.com/open-webui/open-webui/releases/tag/v0.9.5) (published 2026-05-10)
+- GitHub release reference: [`v0.9.5`](https://github.com/open-webui/open-webui/releases/tag/v0.9.5) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/openai-agents-tutorial/README.md
+++ b/tutorials/openai-agents-tutorial/README.md
@@ -76,7 +76,7 @@ Welcome to your journey through the OpenAI Agents SDK! This tutorial takes you f
 
 - repository: [`openai/openai-agents-python`](https://github.com/openai/openai-agents-python)
 - stars: about **26.8k**
-- latest release: [`v0.17.4`](https://github.com/openai/openai-agents-python/releases/tag/v0.17.4) (published 2026-05-26)
+- GitHub release reference: [`v0.17.4`](https://github.com/openai/openai-agents-python/releases/tag/v0.17.4) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/openai-python-sdk-tutorial/README.md
+++ b/tutorials/openai-python-sdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`openai/openai-python`](https://github.com/openai/openai-python)
 - stars: about **30.9k**
-- latest release: [`v2.38.0`](https://github.com/openai/openai-python/releases/tag/v2.38.0) (published 2026-05-21)
+- GitHub release reference: [`v2.38.0`](https://github.com/openai/openai-python/releases/tag/v2.38.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/openai-whisper-tutorial/README.md
+++ b/tutorials/openai-whisper-tutorial/README.md
@@ -99,7 +99,7 @@ Ready to begin? Start with [Chapter 1: Getting Started](01-getting-started.md).
 
 - repository: [`openai/whisper`](https://github.com/openai/whisper)
 - stars: about **101k**
-- latest release: [`v20250625`](https://github.com/openai/whisper/releases/tag/v20250625) (published 2025-06-26)
+- GitHub release reference: [`v20250625`](https://github.com/openai/whisper/releases/tag/v20250625) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/openbb-tutorial/README.md
+++ b/tutorials/openbb-tutorial/README.md
@@ -49,7 +49,7 @@ This track focuses on:
 
 - repository: [`OpenBB-finance/OpenBB`](https://github.com/OpenBB-finance/OpenBB)
 - stars: about **68.4k**
-- latest release: [`ODP`](https://github.com/OpenBB-finance/OpenBB/releases/tag/ODP) (published 2026-04-25)
+- GitHub release reference: [`ODP`](https://github.com/OpenBB-finance/OpenBB/releases/tag/ODP) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/openclaw-tutorial/README.md
+++ b/tutorials/openclaw-tutorial/README.md
@@ -43,7 +43,7 @@ OpenClaw is an open-source, self-hosted personal AI assistant that connects to t
 
 - repository: [`openclaw/openclaw`](https://github.com/openclaw/openclaw)
 - stars: about **376k**
-- latest release: [`v2026.5.28`](https://github.com/openclaw/openclaw/releases/tag/v2026.5.28) (published 2026-05-30)
+- GitHub release reference: [`v2026.5.28`](https://github.com/openclaw/openclaw/releases/tag/v2026.5.28) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/opencode-ai-legacy-tutorial/README.md
+++ b/tutorials/opencode-ai-legacy-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`opencode-ai/opencode`](https://github.com/opencode-ai/opencode)
 - stars: about **12.8k**
-- latest release: [`v0.0.55`](https://github.com/opencode-ai/opencode/releases/tag/v0.0.55) (published 2025-06-27)
+- GitHub release reference: [`v0.0.55`](https://github.com/opencode-ai/opencode/releases/tag/v0.0.55) (checked 2026-06-02; release metadata on GitHub)
 - status: **archived**
 
 ## Mental Model

--- a/tutorials/opencode-tutorial/README.md
+++ b/tutorials/opencode-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`anomalyco/opencode`](https://github.com/anomalyco/opencode)
 - stars: about **168k**
-- latest release: [`v1.15.13`](https://github.com/anomalyco/opencode/releases/tag/v1.15.13) (published 2026-05-30)
+- GitHub release reference: [`v1.15.13`](https://github.com/anomalyco/opencode/releases/tag/v1.15.13) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/openhands-tutorial/README.md
+++ b/tutorials/openhands-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands)
 - stars: about **75.6k**
-- latest release: [`1.7.0`](https://github.com/OpenHands/OpenHands/releases/tag/1.7.0) (published 2026-05-01)
+- GitHub release reference: [`1.7.0`](https://github.com/OpenHands/OpenHands/releases/tag/1.7.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/openskills-tutorial/README.md
+++ b/tutorials/openskills-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`numman-ali/openskills`](https://github.com/numman-ali/openskills)
 - stars: about **10.3k**
-- latest release: [`v1.5.0`](https://github.com/numman-ali/openskills/releases/tag/v1.5.0) (published 2026-01-17)
+- GitHub release reference: [`v1.5.0`](https://github.com/numman-ali/openskills/releases/tag/v1.5.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/openspec-tutorial/README.md
+++ b/tutorials/openspec-tutorial/README.md
@@ -30,7 +30,7 @@ This track focuses on:
 
 - repository: [`Fission-AI/OpenSpec`](https://github.com/Fission-AI/OpenSpec)
 - stars: about **52.1k**
-- latest release: [`v1.3.1`](https://github.com/Fission-AI/OpenSpec/releases/tag/v1.3.1) (published 2026-04-21)
+- GitHub release reference: [`v1.3.1`](https://github.com/Fission-AI/OpenSpec/releases/tag/v1.3.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/opensrc-tutorial/README.md
+++ b/tutorials/opensrc-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`vercel-labs/opensrc`](https://github.com/vercel-labs/opensrc)
 - stars: about **2.4k**
-- latest release: [`v0.7.2`](https://github.com/vercel-labs/opensrc/releases/tag/v0.7.2) (published 2026-04-18)
+- GitHub release reference: [`v0.7.2`](https://github.com/vercel-labs/opensrc/releases/tag/v0.7.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/outlines-tutorial/README.md
+++ b/tutorials/outlines-tutorial/README.md
@@ -43,7 +43,7 @@ This track focuses on:
 
 - repository: [`dottxt-ai/outlines`](https://github.com/dottxt-ai/outlines)
 - stars: about **13.9k**
-- latest release: [`1.3.0`](https://github.com/dottxt-ai/outlines/releases/tag/1.3.0) (published 2026-05-13)
+- GitHub release reference: [`1.3.0`](https://github.com/dottxt-ai/outlines/releases/tag/1.3.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/perplexica-tutorial/README.md
+++ b/tutorials/perplexica-tutorial/README.md
@@ -78,7 +78,7 @@ Welcome to your journey through AI-powered search technology! This tutorial expl
 
 - repository: [`ItzCrazyKns/Perplexica`](https://github.com/ItzCrazyKns/Perplexica)
 - stars: about **35k**
-- latest release: [`v1.12.2`](https://github.com/ItzCrazyKns/Perplexica/releases/tag/v1.12.2) (published 2026-04-10)
+- GitHub release reference: [`v1.12.2`](https://github.com/ItzCrazyKns/Perplexica/releases/tag/v1.12.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/phidata-tutorial/README.md
+++ b/tutorials/phidata-tutorial/README.md
@@ -45,7 +45,7 @@ This track focuses on:
 
 - repository: [`agno-agi/agno`](https://github.com/agno-agi/agno)
 - stars: about **40.4k**
-- latest release: [`v2.6.9`](https://github.com/agno-agi/agno/releases/tag/v2.6.9) (published 2026-05-21)
+- GitHub release reference: [`v2.6.9`](https://github.com/agno-agi/agno/releases/tag/v2.6.9) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/photoprism-tutorial/README.md
+++ b/tutorials/photoprism-tutorial/README.md
@@ -44,7 +44,7 @@ This comprehensive tutorial will guide you through PhotoPrism, a powerful AI-pow
 
 - repository: [`photoprism/photoprism`](https://github.com/photoprism/photoprism)
 - stars: about **39.7k**
-- latest release: [`260523-0544f71c1`](https://github.com/photoprism/photoprism/releases/tag/260523-0544f71c1) (published 2026-05-23)
+- GitHub release reference: [`260523-0544f71c1`](https://github.com/photoprism/photoprism/releases/tag/260523-0544f71c1) (checked 2026-06-02; release metadata on GitHub)
 
 ## 📚 Tutorial Chapters
 

--- a/tutorials/plandex-tutorial/README.md
+++ b/tutorials/plandex-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`plandex-ai/plandex`](https://github.com/plandex-ai/plandex)
 - stars: about **15.4k**
-- latest release: [`cli/v2.2.1`](https://github.com/plandex-ai/plandex/releases/tag/cli/v2.2.1) (published 2025-07-16)
+- GitHub release reference: [`cli/v2.2.1`](https://github.com/plandex-ai/plandex/releases/tag/cli/v2.2.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/plane-tutorial/README.md
+++ b/tutorials/plane-tutorial/README.md
@@ -35,7 +35,7 @@ This track focuses on:
 
 - repository: [`makeplane/plane`](https://github.com/makeplane/plane)
 - stars: about **50k**
-- latest release: [`v1.3.1`](https://github.com/makeplane/plane/releases/tag/v1.3.1) (published 2026-05-14)
+- GitHub release reference: [`v1.3.1`](https://github.com/makeplane/plane/releases/tag/v1.3.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/planning-with-files-tutorial/README.md
+++ b/tutorials/planning-with-files-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`OthmanAdi/planning-with-files`](https://github.com/OthmanAdi/planning-with-files)
 - stars: about **22.5k**
-- latest release: [`v2.43.0`](https://github.com/OthmanAdi/planning-with-files/releases/tag/v2.43.0) (published 2026-05-26)
+- GitHub release reference: [`v2.43.0`](https://github.com/OthmanAdi/planning-with-files/releases/tag/v2.43.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/playwright-mcp-tutorial/README.md
+++ b/tutorials/playwright-mcp-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`microsoft/playwright-mcp`](https://github.com/microsoft/playwright-mcp)
 - stars: about **33.3k**
-- latest release: [`v0.0.75`](https://github.com/microsoft/playwright-mcp/releases/tag/v0.0.75) (published 2026-05-07)
+- GitHub release reference: [`v0.0.75`](https://github.com/microsoft/playwright-mcp/releases/tag/v0.0.75) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/posthog-tutorial/README.md
+++ b/tutorials/posthog-tutorial/README.md
@@ -77,7 +77,7 @@ Welcome to your journey through modern product analytics! This tutorial explores
 
 - repository: [`PostHog/posthog`](https://github.com/PostHog/posthog)
 - stars: about **34.8k**
-- latest release: [`posthog-cli/v0.7.14`](https://github.com/PostHog/posthog/releases/tag/posthog-cli/v0.7.14) (published 2026-05-29)
+- GitHub release reference: [`posthog-cli/v0.7.14`](https://github.com/PostHog/posthog/releases/tag/posthog-cli/v0.7.14) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/pydantic-ai-tutorial/README.md
+++ b/tutorials/pydantic-ai-tutorial/README.md
@@ -43,7 +43,7 @@ This track focuses on:
 
 - repository: [`pydantic/pydantic-ai`](https://github.com/pydantic/pydantic-ai)
 - stars: about **17.4k**
-- latest release: [`v1.104.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v1.104.0) (published 2026-05-29)
+- GitHub release reference: [`v1.104.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v1.104.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/quivr-tutorial/README.md
+++ b/tutorials/quivr-tutorial/README.md
@@ -78,7 +78,7 @@ Welcome to your journey through document-based AI interactions! This tutorial ex
 
 - repository: [`QuivrHQ/quivr`](https://github.com/QuivrHQ/quivr)
 - stars: about **39.2k**
-- latest release: [`core-0.0.33`](https://github.com/QuivrHQ/quivr/releases/tag/core-0.0.33) (published 2025-02-04)
+- GitHub release reference: [`core-0.0.33`](https://github.com/QuivrHQ/quivr/releases/tag/core-0.0.33) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/qwen-agent-tutorial/README.md
+++ b/tutorials/qwen-agent-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`QwenLM/Qwen-Agent`](https://github.com/QwenLM/Qwen-Agent)
 - stars: about **16.4k**
-- latest release: [`v0.0.26`](https://github.com/QwenLM/Qwen-Agent/releases/tag/v0.0.26) (published 2025-05-29)
+- GitHub release reference: [`v0.0.26`](https://github.com/QwenLM/Qwen-Agent/releases/tag/v0.0.26) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/ragflow-tutorial/README.md
+++ b/tutorials/ragflow-tutorial/README.md
@@ -49,7 +49,7 @@ This track focuses on:
 
 - repository: [`infiniflow/ragflow`](https://github.com/infiniflow/ragflow)
 - stars: about **81.6k**
-- latest release: [`v0.25.6`](https://github.com/infiniflow/ragflow/releases/tag/v0.25.6) (published 2026-05-27)
+- GitHub release reference: [`v0.25.6`](https://github.com/infiniflow/ragflow/releases/tag/v0.25.6) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/react-fiber-tutorial/README.md
+++ b/tutorials/react-fiber-tutorial/README.md
@@ -93,7 +93,7 @@ graph TB
 
 - repository: [`facebook/react`](https://github.com/facebook/react)
 - stars: about **245k**
-- latest release: [`v19.2.6`](https://github.com/facebook/react/releases/tag/v19.2.6) (published 2026-05-06)
+- GitHub release reference: [`v19.2.6`](https://github.com/facebook/react/releases/tag/v19.2.6) (checked 2026-06-02; release metadata on GitHub)
 
 ## Prerequisites
 

--- a/tutorials/refly-tutorial/README.md
+++ b/tutorials/refly-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`refly-ai/refly`](https://github.com/refly-ai/refly)
 - stars: about **7.3k**
-- latest release: [`v1.1.0`](https://github.com/refly-ai/refly/releases/tag/v1.1.0) (published 2026-02-02)
+- GitHub release reference: [`v1.1.0`](https://github.com/refly-ai/refly/releases/tag/v1.1.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/roo-code-tutorial/README.md
+++ b/tutorials/roo-code-tutorial/README.md
@@ -29,7 +29,7 @@ This track teaches you how to:
 
 - repository: [`RooCodeInc/Roo-Code`](https://github.com/RooCodeInc/Roo-Code)
 - stars: about **24.2k**
-- latest release: [`v3.54.0`](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.54.0) (published 2026-05-15)
+- GitHub release reference: [`v3.54.0`](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.54.0) (checked 2026-06-02; release metadata on GitHub)
 - status: **archived**
 
 ## Roo Code Mental Model

--- a/tutorials/semantic-kernel-tutorial/README.md
+++ b/tutorials/semantic-kernel-tutorial/README.md
@@ -86,7 +86,7 @@ flowchart TD
 
 - repository: [`microsoft/semantic-kernel`](https://github.com/microsoft/semantic-kernel)
 - stars: about **28k**
-- latest release: [`dotnet-1.77.0`](https://github.com/microsoft/semantic-kernel/releases/tag/dotnet-1.77.0) (published 2026-05-28)
+- GitHub release reference: [`dotnet-1.77.0`](https://github.com/microsoft/semantic-kernel/releases/tag/dotnet-1.77.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/serena-tutorial/README.md
+++ b/tutorials/serena-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`oraios/serena`](https://github.com/oraios/serena)
 - stars: about **24.8k**
-- latest release: [`v1.5.3`](https://github.com/oraios/serena/releases/tag/v1.5.3) (published 2026-05-26)
+- GitHub release reference: [`v1.5.3`](https://github.com/oraios/serena/releases/tag/v1.5.3) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/shotgun-tutorial/README.md
+++ b/tutorials/shotgun-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`shotgun-sh/shotgun`](https://github.com/shotgun-sh/shotgun)
 - stars: about **675**
-- latest release: [`0.13.0`](https://github.com/shotgun-sh/shotgun/releases/tag/0.13.0) (published 2026-04-14)
+- GitHub release reference: [`0.13.0`](https://github.com/shotgun-sh/shotgun/releases/tag/0.13.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/sillytavern-tutorial/README.md
+++ b/tutorials/sillytavern-tutorial/README.md
@@ -50,7 +50,7 @@ This track focuses on:
 
 - repository: [`SillyTavern/SillyTavern`](https://github.com/SillyTavern/SillyTavern)
 - stars: about **28.7k**
-- latest release: [`1.18.0`](https://github.com/SillyTavern/SillyTavern/releases/tag/1.18.0) (published 2026-05-03)
+- GitHub release reference: [`1.18.0`](https://github.com/SillyTavern/SillyTavern/releases/tag/1.18.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/siyuan-tutorial/README.md
+++ b/tutorials/siyuan-tutorial/README.md
@@ -74,7 +74,7 @@ Welcome to your journey through SiYuan's architecture! This tutorial explores ho
 
 - repository: [`siyuan-note/siyuan`](https://github.com/siyuan-note/siyuan)
 - stars: about **44.2k**
-- latest release: [`v3.6.5`](https://github.com/siyuan-note/siyuan/releases/tag/v3.6.5) (published 2026-04-21)
+- GitHub release reference: [`v3.6.5`](https://github.com/siyuan-note/siyuan/releases/tag/v3.6.5) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/smolagents-tutorial/README.md
+++ b/tutorials/smolagents-tutorial/README.md
@@ -80,7 +80,7 @@ flowchart TD
 
 - repository: [`huggingface/smolagents`](https://github.com/huggingface/smolagents)
 - stars: about **27.6k**
-- latest release: [`v1.26.0`](https://github.com/huggingface/smolagents/releases/tag/v1.26.0) (published 2026-05-29)
+- GitHub release reference: [`v1.26.0`](https://github.com/huggingface/smolagents/releases/tag/v1.26.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Chapter Guide
 

--- a/tutorials/stagewise-tutorial/README.md
+++ b/tutorials/stagewise-tutorial/README.md
@@ -30,7 +30,7 @@ This track focuses on:
 
 - repository: [`stagewise-io/stagewise`](https://github.com/stagewise-io/stagewise)
 - stars: about **6.7k**
-- latest release: [`stagewise@1.3.0`](https://github.com/stagewise-io/stagewise/releases/tag/stagewise@1.3.0) (published 2026-05-29)
+- GitHub release reference: [`stagewise@1.3.0`](https://github.com/stagewise-io/stagewise/releases/tag/stagewise@1.3.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/strands-agents-tutorial/README.md
+++ b/tutorials/strands-agents-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`strands-agents/sdk-python`](https://github.com/strands-agents/sdk-python)
 - stars: about **6k**
-- latest release: [`v1.41.0`](https://github.com/strands-agents/sdk-python/releases/tag/v1.41.0) (published 2026-05-21)
+- GitHub release reference: [`v1.41.0`](https://github.com/strands-agents/sdk-python/releases/tag/v1.41.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/supabase-tutorial/README.md
+++ b/tutorials/supabase-tutorial/README.md
@@ -86,7 +86,7 @@ Welcome to your journey through modern backend development! This tutorial explor
 
 - repository: [`supabase/supabase`](https://github.com/supabase/supabase)
 - stars: about **103k**
-- latest release: [`v1.26.05`](https://github.com/supabase/supabase/releases/tag/v1.26.05) (published 2026-05-07)
+- GitHub release reference: [`v1.26.05`](https://github.com/supabase/supabase/releases/tag/v1.26.05) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/superagi-tutorial/README.md
+++ b/tutorials/superagi-tutorial/README.md
@@ -80,7 +80,7 @@ Welcome to your journey through autonomous AI agent development! This tutorial e
 
 - repository: [`TransformerOptimus/SuperAGI`](https://github.com/TransformerOptimus/SuperAGI)
 - stars: about **17.6k**
-- latest release: [`v0.0.14`](https://github.com/TransformerOptimus/SuperAGI/releases/tag/v0.0.14) (published 2024-01-16)
+- GitHub release reference: [`v0.0.14`](https://github.com/TransformerOptimus/SuperAGI/releases/tag/v0.0.14) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/superset-terminal-tutorial/README.md
+++ b/tutorials/superset-terminal-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`superset-sh/superset`](https://github.com/superset-sh/superset)
 - stars: about **11.5k**
-- latest release: [`desktop-v1.12.1`](https://github.com/superset-sh/superset/releases/tag/desktop-v1.12.1) (published 2026-05-28)
+- GitHub release reference: [`desktop-v1.12.1`](https://github.com/superset-sh/superset/releases/tag/desktop-v1.12.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/swe-agent-tutorial/README.md
+++ b/tutorials/swe-agent-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`SWE-agent/SWE-agent`](https://github.com/SWE-agent/SWE-agent)
 - stars: about **19.4k**
-- latest release: [`v1.1.0`](https://github.com/SWE-agent/SWE-agent/releases/tag/v1.1.0) (published 2025-05-22)
+- GitHub release reference: [`v1.1.0`](https://github.com/SWE-agent/SWE-agent/releases/tag/v1.1.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/sweep-tutorial/README.md
+++ b/tutorials/sweep-tutorial/README.md
@@ -32,7 +32,7 @@ This track focuses on:
 
 - repository: [`sweepai/sweep`](https://github.com/sweepai/sweep)
 - stars: about **7.7k**
-- latest release: [`sweep-sandbox-v1`](https://github.com/sweepai/sweep/releases/tag/sweep-sandbox-v1) (published 2023-09-11)
+- GitHub release reference: [`sweep-sandbox-v1`](https://github.com/sweepai/sweep/releases/tag/sweep-sandbox-v1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/tabby-tutorial/README.md
+++ b/tutorials/tabby-tutorial/README.md
@@ -30,7 +30,7 @@ This track focuses on:
 
 - repository: [`TabbyML/tabby`](https://github.com/TabbyML/tabby)
 - stars: about **33.6k**
-- latest release: [`v0.32.0`](https://github.com/TabbyML/tabby/releases/tag/v0.32.0) (published 2026-01-25)
+- GitHub release reference: [`v0.32.0`](https://github.com/TabbyML/tabby/releases/tag/v0.32.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/taskade-mcp-tutorial/README.md
+++ b/tutorials/taskade-mcp-tutorial/README.md
@@ -25,7 +25,7 @@ Instead of manually wiring custom integrations, you can expose Taskade operation
 
 - repository: [`taskade/mcp`](https://github.com/taskade/mcp)
 - stars: about **148**
-- latest release: [`v0.0.1`](https://github.com/taskade/mcp/releases/tag/v0.0.1) (published 2026-02-13)
+- GitHub release reference: [`v0.0.1`](https://github.com/taskade/mcp/releases/tag/v0.0.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/teable-tutorial/README.md
+++ b/tutorials/teable-tutorial/README.md
@@ -128,7 +128,7 @@ Ready to begin? Start with [Chapter 1: System Overview](01-system-overview.md).
 
 - repository: [`teableio/teable`](https://github.com/teableio/teable)
 - stars: about **21.3k**
-- latest release: [`release.2026-05-29T09-31-13Z.1795`](https://github.com/teableio/teable/releases/tag/release.2026-05-29T09-31-13Z.1795) (published 2026-05-30)
+- GitHub release reference: [`release.2026-05-29T09-31-13Z.1795`](https://github.com/teableio/teable/releases/tag/release.2026-05-29T09-31-13Z.1795) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/tiktoken-tutorial/README.md
+++ b/tutorials/tiktoken-tutorial/README.md
@@ -202,7 +202,7 @@ Ready to begin? Start with [Chapter 1: Getting Started](01-getting-started.md).
 
 - repository: [`openai/tiktoken`](https://github.com/openai/tiktoken)
 - stars: about **18.4k**
-- latest release: [`0.13.0`](https://github.com/openai/tiktoken/releases/tag/0.13.0) (published 2026-05-15)
+- GitHub release reference: [`0.13.0`](https://github.com/openai/tiktoken/releases/tag/0.13.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Source References
 

--- a/tutorials/tldraw-tutorial/README.md
+++ b/tutorials/tldraw-tutorial/README.md
@@ -40,7 +40,7 @@ This track focuses on:
 
 - repository: [`tldraw/tldraw`](https://github.com/tldraw/tldraw)
 - stars: about **47.5k**
-- latest release: [`v5.0.2`](https://github.com/tldraw/tldraw/releases/tag/v5.0.2) (published 2026-05-20)
+- GitHub release reference: [`v5.0.2`](https://github.com/tldraw/tldraw/releases/tag/v5.0.2) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/turborepo-tutorial/README.md
+++ b/tutorials/turborepo-tutorial/README.md
@@ -84,7 +84,7 @@ Welcome to your journey through high-performance monorepo development! This tuto
 
 - repository: [`vercel/turborepo`](https://github.com/vercel/turborepo)
 - stars: about **30.5k**
-- latest release: [`v2.9.16`](https://github.com/vercel/turborepo/releases/tag/v2.9.16) (published 2026-05-28)
+- GitHub release reference: [`v2.9.16`](https://github.com/vercel/turborepo/releases/tag/v2.9.16) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/vercel-ai-tutorial/README.md
+++ b/tutorials/vercel-ai-tutorial/README.md
@@ -27,7 +27,7 @@ The AI SDK is one of the most widely used TypeScript toolkits for shipping moder
 
 - repository: [`vercel/ai`](https://github.com/vercel/ai)
 - stars: about **24.6k**
-- latest release: [`@ai-sdk/xai@3.0.93`](https://github.com/vercel/ai/releases/tag/@ai-sdk/xai@3.0.93) (published 2026-05-30)
+- GitHub release reference: [`@ai-sdk/xai@3.0.93`](https://github.com/vercel/ai/releases/tag/@ai-sdk/xai@3.0.93) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/vibe-kanban-tutorial/README.md
+++ b/tutorials/vibe-kanban-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`BloopAI/vibe-kanban`](https://github.com/BloopAI/vibe-kanban)
 - stars: about **26.7k**
-- latest release: [`v0.1.44-20260424091429`](https://github.com/BloopAI/vibe-kanban/releases/tag/v0.1.44-20260424091429) (published 2026-04-24)
+- GitHub release reference: [`v0.1.44-20260424091429`](https://github.com/BloopAI/vibe-kanban/releases/tag/v0.1.44-20260424091429) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/vibesdk-tutorial/README.md
+++ b/tutorials/vibesdk-tutorial/README.md
@@ -29,7 +29,7 @@ This track focuses on:
 
 - repository: [`cloudflare/vibesdk`](https://github.com/cloudflare/vibesdk)
 - stars: about **5.1k**
-- latest release: [`v1.5.0`](https://github.com/cloudflare/vibesdk/releases/tag/v1.5.0) (published 2026-02-06)
+- GitHub release reference: [`v1.5.0`](https://github.com/cloudflare/vibesdk/releases/tag/v1.5.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 

--- a/tutorials/vllm-tutorial/README.md
+++ b/tutorials/vllm-tutorial/README.md
@@ -71,7 +71,7 @@ flowchart TD
 
 - repository: [`vllm-project/vllm`](https://github.com/vllm-project/vllm)
 - stars: about **81.6k**
-- latest release: [`v0.22.0`](https://github.com/vllm-project/vllm/releases/tag/v0.22.0) (published 2026-05-29)
+- GitHub release reference: [`v0.22.0`](https://github.com/vllm-project/vllm/releases/tag/v0.22.0) (checked 2026-06-02; release metadata on GitHub)
 
 ## Core Technologies
 

--- a/tutorials/whisper-cpp-tutorial/README.md
+++ b/tutorials/whisper-cpp-tutorial/README.md
@@ -72,7 +72,7 @@ Welcome to your journey through Whisper.cpp! This tutorial takes you from basic 
 
 - repository: [`ggml-org/whisper.cpp`](https://github.com/ggml-org/whisper.cpp)
 - stars: about **50.3k**
-- latest release: [`v1.8.5`](https://github.com/ggml-org/whisper.cpp/releases/tag/v1.8.5) (published 2026-05-29)
+- GitHub release reference: [`v1.8.5`](https://github.com/ggml-org/whisper.cpp/releases/tag/v1.8.5) (checked 2026-06-02; release metadata on GitHub)
 
 ## What You Will Learn
 

--- a/tutorials/windmill-tutorial/README.md
+++ b/tutorials/windmill-tutorial/README.md
@@ -36,7 +36,7 @@ This track focuses on:
 
 - repository: [`windmill-labs/windmill`](https://github.com/windmill-labs/windmill)
 - stars: about **16.6k**
-- latest release: [`v1.713.1`](https://github.com/windmill-labs/windmill/releases/tag/v1.713.1) (published 2026-06-01)
+- GitHub release reference: [`v1.713.1`](https://github.com/windmill-labs/windmill/releases/tag/v1.713.1) (checked 2026-06-02; release metadata on GitHub)
 
 ## Mental Model
 


### PR DESCRIPTION
## Summary
Converts release metadata lines from stale-prone `latest release` claims into checked GitHub release references.

## Why
The audit found stale `latest release` wording even when the referenced tags still matched GitHub's release metadata. The issue was wording: old release dates looked like current freshness claims.

## What changed
- Replaced tutorial README `latest release` lines with `GitHub release reference` lines.
- Kept a current `checked 2026-06-02` marker and linked tags back to GitHub release pages.
- Removed old published-date freshness markers from README lines so the staleness gate stays meaningful.
- Updated `scripts/refresh_tutorial_snapshots.py` so future refreshes emit the safer wording.
- Updated `templates/tutorial-index-template-v2.md` to match the new convention.

## Validation
- `python3 scripts/release_claims_audit.py --max-age-days 120 --fail-on-stale`
  - `stale_release_claim_count=0`
- `python3 scripts/staleness_audit.py --max-age-days 10 --fail-on-stale`
  - `stale_marker_count=0`
- `python3 scripts/docs_health.py --root .`
- `python3 scripts/check_index_format_v2.py --root .`
- Generated discoverability assets to `/tmp` and diffed all CI-validated outputs.
